### PR TITLE
The Future of Pre-built Binaries in Nitro-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1973,6 +1973,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2364,6 +2377,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2404,6 +2428,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2427,6 +2457,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2454,15 +2501,18 @@ dependencies = [
  "num-traits",
  "openssl",
  "page_size",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2 0.9.9",
  "signal-hook",
+ "tar",
  "tempfile",
  "tokio",
  "url",
  "vmm-sys-util",
  "vsock",
+ "xz2",
 ]
 
 [[package]]
@@ -2888,6 +2938,46 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
 
 [[package]]
 name = "resolv-conf"
@@ -3346,6 +3436,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3354,6 +3450,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3528,6 +3645,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -3808,6 +3935,19 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -4094,6 +4234,15 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,10 +116,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
 
 [[package]]
 name = "async-trait"
@@ -891,6 +918,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -1193,6 +1226,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,6 +1291,12 @@ checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -1337,6 +1385,25 @@ name = "data-encoding"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+
+[[package]]
+name = "deadpool"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "retain_mut",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "deranged"
@@ -1500,6 +1567,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,6 +1704,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1652,6 +1740,12 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -1683,13 +1777,24 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1818,7 +1923,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.69",
  "tinyvec",
  "tokio",
@@ -1839,7 +1944,7 @@ dependencies = [
  "lru-cache",
  "once_cell",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "resolv-conf",
  "smallvec",
  "thiserror 1.0.69",
@@ -1921,6 +2026,27 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http-types"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "base64 0.13.1",
+ "futures-lite",
+ "http 0.2.12",
+ "infer",
+ "pin-project-lite",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "serde_urlencoded",
+ "url",
 ]
 
 [[package]]
@@ -2268,6 +2394,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "infer"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
+
+[[package]]
 name = "inotify"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2513,7 +2645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -2574,6 +2706,7 @@ dependencies = [
  "url",
  "vmm-sys-util",
  "vsock",
+ "wiremock",
  "xz2",
 ]
 
@@ -2812,6 +2945,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2943,13 +3082,36 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2959,7 +3121,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -2968,7 +3139,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2986,7 +3166,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -3077,6 +3257,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "retain_mut"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3099,7 +3285,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -3310,6 +3496,17 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3579,7 +3776,7 @@ checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand 2.3.0",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -3911,6 +4108,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -3999,12 +4197,18 @@ dependencies = [
  "idna",
  "log",
  "nix 0.26.4",
- "rand",
+ "rand 0.8.5",
  "tempfile",
  "threadpool",
  "vsock",
  "yaml-rust2",
 ]
+
+[[package]]
+name = "waker-fn"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "want"
@@ -4014,6 +4218,12 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -4314,6 +4524,28 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.5.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a3a53eaf34f390dd30d7b1b078287dd05df2aa2e21a589ccb80f5c7253c2e9"
+dependencies = [
+ "assert-json-diff",
+ "async-trait",
+ "base64 0.21.7",
+ "deadpool",
+ "futures",
+ "futures-timer",
+ "http-types",
+ "hyper 0.14.32",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,28 +151,58 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcdcf0d683fe9c23d32cf5b53c9918ea0a500375a9fb20109802552658e576c9"
+dependencies = [
+ "aws-credential-types 0.55.3",
+ "aws-http",
+ "aws-sdk-sso 0.28.0",
+ "aws-sdk-sts 0.28.0",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-client",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-http-tower",
+ "aws-smithy-json 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-types 0.55.3",
+ "bytes",
+ "fastrand 1.9.0",
+ "hex",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "ring 0.16.20",
+ "time",
+ "tokio",
+ "tower",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-config"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48730d0b4c3d91c43d0d37168831d9fd0e065ad4a889a2ee9faf8d34c3d2804d"
 dependencies = [
- "aws-credential-types",
+ "aws-credential-types 1.2.1",
  "aws-runtime",
- "aws-sdk-sso",
+ "aws-sdk-sso 1.19.0",
  "aws-sdk-ssooidc",
- "aws-sdk-sts",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-sdk-sts 1.19.0",
+ "aws-smithy-async 1.2.4",
+ "aws-smithy-http 0.60.12",
+ "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
+ "aws-smithy-types 1.2.12",
+ "aws-types 1.1.9",
  "bytes",
- "fastrand",
+ "fastrand 2.3.0",
  "hex",
  "http 0.2.12",
  "hyper 0.14.32",
- "ring",
+ "ring 0.17.8",
  "time",
  "tokio",
  "tracing",
@@ -182,14 +212,61 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fcdb2f7acbc076ff5ad05e7864bdb191ca70a6fd07668dc3a1a8bcd051de5ae"
+dependencies = [
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "fastrand 1.9.0",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
 dependencies = [
- "aws-smithy-async",
+ "aws-smithy-async 1.2.4",
  "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-smithy-types 1.2.12",
  "zeroize",
+]
+
+[[package]]
+name = "aws-endpoint"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cce1c41a6cfaa726adee9ebb9a56fcd2bbfd8be49fd8a04c5e20fd968330b04"
+dependencies = [
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-types 0.55.3",
+ "http 0.2.12",
+ "regex",
+ "tracing",
+]
+
+[[package]]
+name = "aws-http"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aadbc44e7a8f3e71c8b374e03ecd972869eb91dd2bc89ed018954a52ba84bc44"
+dependencies = [
+ "aws-credential-types 0.55.3",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-types 0.55.3",
+ "bytes",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
 ]
 
 [[package]]
@@ -214,11 +291,11 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be2355fd67972562e7402384bf20c7d913070e4f0d0d1d722c4a3cbc3c977d6c"
 dependencies = [
- "aws-config",
+ "aws-config 1.1.10",
  "aws-nitro-enclaves-cose",
  "aws-sdk-kms",
  "aws-smithy-runtime",
- "aws-types",
+ "aws-types 1.1.9",
  "byteorder",
  "chrono",
  "clap 3.2.25",
@@ -241,15 +318,15 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4ee6903f9d0197510eb6b44c4d86b493011d08b4992938f7b9be0333b6685aa"
 dependencies = [
- "aws-credential-types",
- "aws-sigv4",
- "aws-smithy-async",
- "aws-smithy-http",
+ "aws-credential-types 1.2.1",
+ "aws-sigv4 1.2.7",
+ "aws-smithy-async 1.2.4",
+ "aws-smithy-http 0.60.12",
  "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
+ "aws-smithy-types 1.2.12",
+ "aws-types 1.1.9",
  "bytes",
- "fastrand",
+ "fastrand 2.3.0",
  "http 0.2.12",
  "http-body 0.4.6",
  "percent-encoding",
@@ -264,19 +341,77 @@ version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cfadd284d25d59c715bec5d1b6a20724eea3f85332a632f56056ce3fc6ea934"
 dependencies = [
- "aws-credential-types",
+ "aws-credential-types 1.2.1",
  "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-async 1.2.4",
+ "aws-smithy-http 0.60.12",
+ "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
+ "aws-smithy-types 1.2.12",
+ "aws-types 1.1.9",
  "bytes",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba197193cbb4bcb6aad8d99796b2291f36fa89562ded5d4501363055b0de89f"
+dependencies = [
+ "aws-credential-types 0.55.3",
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "aws-sigv4 0.55.3",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-checksums",
+ "aws-smithy-client",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-http-tower",
+ "aws-smithy-json 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-smithy-xml 0.55.3",
+ "aws-types 0.55.3",
+ "bytes",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "tokio-stream",
+ "tower",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8b812340d86d4a766b2ca73f740dfd47a97c2dff0c06c8517a16d88241957e4"
+dependencies = [
+ "aws-credential-types 0.55.3",
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-client",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-http-tower",
+ "aws-smithy-json 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-types 0.55.3",
+ "bytes",
+ "http 0.2.12",
+ "regex",
+ "tokio-stream",
+ "tower",
  "tracing",
 ]
 
@@ -286,15 +421,15 @@ version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2be5ba83b077b67a6f7a1927eb6b212bf556e33bd74b5eaa5aa6e421910803a"
 dependencies = [
- "aws-credential-types",
+ "aws-credential-types 1.2.1",
  "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-async 1.2.4",
+ "aws-smithy-http 0.60.12",
+ "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
+ "aws-smithy-types 1.2.12",
+ "aws-types 1.1.9",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -308,15 +443,15 @@ version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "022ca669825f841aef17b12d4354ef2b8651e4664be49f2d9ea13e4062a80c9f"
 dependencies = [
- "aws-credential-types",
+ "aws-credential-types 1.2.1",
  "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
+ "aws-smithy-async 1.2.4",
+ "aws-smithy-http 0.60.12",
+ "aws-smithy-json 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
+ "aws-smithy-types 1.2.12",
+ "aws-types 1.1.9",
  "bytes",
  "http 0.2.12",
  "once_cell",
@@ -326,24 +461,86 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "265fac131fbfc188e5c3d96652ea90ecc676a934e3174eaaee523c6cec040b3b"
+dependencies = [
+ "aws-credential-types 0.55.3",
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-client",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-http-tower",
+ "aws-smithy-json 0.55.3",
+ "aws-smithy-query 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "aws-smithy-xml 0.55.3",
+ "aws-types 0.55.3",
+ "bytes",
+ "http 0.2.12",
+ "regex",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e4a5f5cb007347c1ab34a6d56456301dfada921fc9e57d687ecb08baddd11ff"
 dependencies = [
- "aws-credential-types",
+ "aws-credential-types 1.2.1",
  "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-query",
+ "aws-smithy-async 1.2.4",
+ "aws-smithy-http 0.60.12",
+ "aws-smithy-json 0.60.7",
+ "aws-smithy-query 0.60.7",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-smithy-xml",
- "aws-types",
+ "aws-smithy-types 1.2.12",
+ "aws-smithy-xml 0.60.9",
+ "aws-types 1.1.9",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sig-auth"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b94acb10af0c879ecd5c7bdf51cda6679a0a4f4643ce630905a77673bfa3c61"
+dependencies = [
+ "aws-credential-types 0.55.3",
+ "aws-sigv4 0.55.3",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.55.3",
+ "aws-types 0.55.3",
+ "http 0.2.12",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d2ce6f507be68e968a33485ced670111d1cbad161ddbbab1e313c03d37d8f4c"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.55.3",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "sha2 0.10.8",
+ "time",
  "tracing",
 ]
 
@@ -353,10 +550,10 @@ version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "690118821e46967b3c4501d67d7d52dd75106a9c54cf36cefa1985cedbe94e05"
 dependencies = [
- "aws-credential-types",
- "aws-smithy-http",
+ "aws-credential-types 1.2.1",
+ "aws-smithy-http 0.60.12",
  "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-smithy-types 1.2.12",
  "bytes",
  "form_urlencoded",
  "hex",
@@ -372,6 +569,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13bda3996044c202d75b91afeb11a9afae9db9a721c6a7a427410018e286b880"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "aws-smithy-async"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa59d1327d8b5053c54bf2eaae63bf629ba9e904434d0835a28ed3c0ed0a614e"
@@ -382,13 +591,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-checksums"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ed8b96d95402f3f6b8b57eb4e0e45ee365f78b1a924faf20ff6e97abf1eae6"
+dependencies = [
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "bytes",
+ "crc32c",
+ "crc32fast",
+ "hex",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2 0.10.8",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-client"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a86aa6e21e86c4252ad6a0e3e74da9617295d8d6e374d552be7d3059c41cedd"
+dependencies = [
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-http-tower",
+ "aws-smithy-types 0.55.3",
+ "bytes",
+ "fastrand 1.9.0",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-rustls 0.23.2",
+ "lazy_static",
+ "pin-project-lite",
+ "rustls 0.20.9",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460c8da5110835e3d9a717c61f5556b20d03c32a1dec57f8fc559b360f733bb8"
+dependencies = [
+ "aws-smithy-types 0.55.3",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b3b693869133551f135e1f2c77cb0b8277d9e3e17feaf2213f735857c4f0d28"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-types 0.55.3",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "aws-smithy-http"
 version = "0.60.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7809c27ad8da6a6a68c454e651d4962479e81472aa19ae99e59f9aba1f9713cc"
 dependencies = [
  "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-smithy-types 1.2.12",
  "bytes",
  "bytes-utils",
  "futures-core",
@@ -402,12 +690,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-http-tower"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae4f6c5798a247fac98a867698197d9ac22643596dc3777f0c76b91917616b9"
+dependencies = [
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "bytes",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "pin-project-lite",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f9f42fbfa96d095194a632fbac19f60077748eba536eb0b9fecc28659807f8"
+dependencies = [
+ "aws-smithy-types 0.55.3",
+]
+
+[[package]]
 name = "aws-smithy-json"
 version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 1.2.12",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98819eb0b04020a1c791903533b638534ae6c12e2aceda3e6e6fba015608d51d"
+dependencies = [
+ "aws-smithy-types 0.55.3",
+ "urlencoding",
 ]
 
 [[package]]
@@ -416,7 +739,7 @@ version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2fbd61ceb3fe8a1cb7352e42689cec5335833cd9f94103a61e98f9bb61c64bb"
 dependencies = [
- "aws-smithy-types",
+ "aws-smithy-types 1.2.12",
  "urlencoding",
 ]
 
@@ -426,22 +749,22 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c53572b4cd934ee5e8461ad53caa36e9d246aaef42166e3ac539e206a925d330"
 dependencies = [
- "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-async 1.2.4",
+ "aws-smithy-http 0.60.12",
  "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-smithy-types 1.2.12",
  "bytes",
- "fastrand",
+ "fastrand 2.3.0",
  "h2",
  "http 0.2.12",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "hyper 0.14.32",
- "hyper-rustls",
+ "hyper-rustls 0.24.2",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
- "rustls",
+ "rustls 0.21.12",
  "tokio",
  "tracing",
 ]
@@ -452,8 +775,8 @@ version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92165296a47a812b267b4f41032ff8069ab7ff783696d217f0994a0d7ab585cd"
 dependencies = [
- "aws-smithy-async",
- "aws-smithy-types",
+ "aws-smithy-async 1.2.4",
+ "aws-smithy-types 1.2.12",
  "bytes",
  "http 0.2.12",
  "http 1.2.0",
@@ -461,6 +784,19 @@ dependencies = [
  "tokio",
  "tracing",
  "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16a3d0bf4f324f4ef9793b86a1701d9700fbcdbd12a846da45eed104c634c6e8"
+dependencies = [
+ "base64-simd",
+ "itoa",
+ "num-integer",
+ "ryu",
+ "time",
 ]
 
 [[package]]
@@ -491,6 +827,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1b9d12875731bd07e767be7baad95700c3137b56730ec9ddeedb52a5e5ca63b"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-smithy-xml"
 version = "0.60.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab0b0166827aa700d3dc519f72f8b3a91c35d0b8d042dc5d643a91e6f80648fc"
@@ -500,14 +845,30 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
+version = "0.55.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd209616cc8d7bfb82f87811a5c655dc97537f592689b18743bddf5dc5c4829"
+dependencies = [
+ "aws-credential-types 0.55.3",
+ "aws-smithy-async 0.55.3",
+ "aws-smithy-client",
+ "aws-smithy-http 0.55.3",
+ "aws-smithy-types 0.55.3",
+ "http 0.2.12",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
+name = "aws-types"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb278e322f16f59630a83b6b2dc992a0b48aa74ed47b4130f193fae0053d713"
 dependencies = [
- "aws-credential-types",
- "aws-smithy-async",
+ "aws-credential-types 1.2.1",
+ "aws-smithy-async 1.2.4",
  "aws-smithy-runtime-api",
- "aws-smithy-types",
+ "aws-smithy-types 1.2.12",
  "http 0.2.12",
  "rustc_version",
  "tracing",
@@ -862,6 +1223,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1439,15 @@ checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -1564,6 +1943,21 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+dependencies = [
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.20.9",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls 0.23.4",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
@@ -1572,10 +1966,10 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.32",
  "log",
- "rustls",
+ "rustls 0.21.12",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -1825,6 +2219,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ipconfig"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1967,6 +2370,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2020,7 +2433,9 @@ dependencies = [
 name = "nitro-cli"
 version = "1.3.4"
 dependencies = [
+ "aws-config 0.55.3",
  "aws-nitro-enclaves-image-format",
+ "aws-sdk-s3",
  "bindgen",
  "chrono",
  "ciborium",
@@ -2044,6 +2459,8 @@ dependencies = [
  "sha2 0.9.9",
  "signal-hook",
  "tempfile",
+ "tokio",
+ "url",
  "vmm-sys-util",
  "vsock",
 ]
@@ -2312,6 +2729,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2464,6 +2901,21 @@ dependencies = [
 
 [[package]]
 name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
@@ -2472,8 +2924,8 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "libc",
- "spin",
- "untrusted",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -2513,12 +2965,24 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
+dependencies = [
+ "log",
+ "ring 0.16.20",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls"
 version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring",
+ "ring 0.17.8",
  "rustls-webpki",
  "sct",
 ]
@@ -2550,8 +3014,8 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.8",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2587,8 +3051,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.8",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2750,6 +3214,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2825,6 +3300,12 @@ dependencies = [
 
 [[package]]
 name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
@@ -2893,7 +3374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
- "fastrand",
+ "fastrand 2.3.0",
  "getrandom",
  "once_cell",
  "rustix",
@@ -3030,6 +3511,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -3050,11 +3532,33 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls 0.20.9",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -3072,6 +3576,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
 name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3083,6 +3609,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3131,6 +3658,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -3307,6 +3840,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
+dependencies = [
+ "ring 0.17.8",
+ "untrusted 0.9.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2484,6 +2484,7 @@ dependencies = [
  "aws-nitro-enclaves-image-format",
  "aws-sdk-s3",
  "bindgen",
+ "bytes",
  "chrono",
  "ciborium",
  "clap 4.4.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,6 +1012,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "byte-unit"
+version = "4.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da78b32057b8fdfc352504708feeba7216dcd65a2c9ab02978cbd288d1279b6c"
+dependencies = [
+ "serde",
+ "utf8-width",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,6 +1267,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctor"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,6 +1369,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,6 +1442,12 @@ dependencies = [
  "tokio",
  "url",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -2484,6 +2542,7 @@ dependencies = [
  "aws-nitro-enclaves-image-format",
  "aws-sdk-s3",
  "bindgen",
+ "byte-unit",
  "bytes",
  "chrono",
  "ciborium",
@@ -2492,6 +2551,7 @@ dependencies = [
  "eif_loader",
  "enclave_build",
  "flexi_logger",
+ "futures-util",
  "hex",
  "inotify",
  "lazy_static",
@@ -2502,6 +2562,7 @@ dependencies = [
  "num-traits",
  "openssl",
  "page_size",
+ "prettytable-rs",
  "reqwest",
  "serde",
  "serde_json",
@@ -2843,6 +2904,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettytable-rs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
+dependencies = [
+ "csv",
+ "encode_unicode",
+ "is-terminal",
+ "lazy_static",
+ "term",
+ "unicode-width",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2903,6 +2978,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags 2.7.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3500,6 +3586,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3782,6 +3879,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3821,6 +3924,12 @@ name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,6 +1436,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1443,6 +1452,18 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2679,6 +2700,7 @@ dependencies = [
  "chrono",
  "ciborium",
  "clap 4.4.18",
+ "dirs",
  "driver-bindings",
  "eif_loader",
  "enclave_build",
@@ -2921,6 +2943,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_str_bytes"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ futures-util = "0.3"
 lazy_static = "1.4.0"
 prettytable-rs = "0.10"
 byte-unit = "4.0"
+dirs = "5.0"
 
 [build-dependencies]
 bindgen = { version=">=0.54" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,10 @@ vsock = "0.3"
 vmm-sys-util = "0.12.1"
 sha2 = "0.9.5"
 hex = "0.4"
+url = "2.4"
+aws-config = "0.55"
+aws-sdk-s3 = "0.28"
+tokio = { version = "1.0", features = ["full"] }
 
 lazy_static = "1.4.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ log = "0.4"
 num-derive = "0.4"
 num-traits = "0.2"
 tempfile = "3.5"
+wiremock = "0.5"
 
 [workspace]
 members = [".", "samples/command_executer", "driver-bindings", "eif_loader", "enclave_build", "vsock_proxy","allocator"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ tokio = { version = "1.0", features = ["full"] }
 reqwest = { version = "0.11", features = ["json"] }
 tar = "0.4"
 xz2 = "0.1"
-
+bytes = "1.0"
 lazy_static = "1.4.0"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,10 @@ reqwest = { version = "0.11", features = ["json"] }
 tar = "0.4"
 xz2 = "0.1"
 bytes = "1.0"
+futures-util = "0.3"
 lazy_static = "1.4.0"
+prettytable-rs = "0.10"
+byte-unit = "4.0"
 
 [build-dependencies]
 bindgen = { version=">=0.54" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ url = "2.4"
 aws-config = "0.55"
 aws-sdk-s3 = "0.28"
 tokio = { version = "1.0", features = ["full"] }
+reqwest = { version = "0.11", features = ["json"] }
+tar = "0.4"
+xz2 = "0.1"
 
 lazy_static = "1.4.0"
 

--- a/src/common/commands_parser.rs
+++ b/src/common/commands_parser.rs
@@ -143,7 +143,25 @@ impl BuildEnclavesArgs {
         })
     }
 }
-
+/// The arguments used by the `fetch-blobs` command.
+#[derive(Debug)]
+    pub enum FetchBlobsArgs {
+        /// The URI of users binary storage.
+        Uri(String),
+        /// The version number of requested blobs.
+        Version(String),
+    }
+    impl FetchBlobsArgs {
+        /// Creating and matching arguments for `fetch-blobs` command.
+        pub fn new_with(args: &ArgMatches) -> NitroCliResult<Self> {
+            match (args.get_one::<String>("URI"), args.get_one::<String>("version")) {
+                (Some(uri), None) => Ok(FetchBlobsArgs::Uri(uri.to_string())),
+                (None, Some(version)) => Ok(FetchBlobsArgs::Version(version.to_string())),
+                (Some(_), Some(_)) => Err(new_nitro_cli_failure!("Cannot specify both uri and version",NitroCliErrorEnum::ConflictingArgument)),
+                (None, None) => Err(new_nitro_cli_failure!("Either uri or version must be provided",NitroCliErrorEnum::MissingArgument)),
+            }
+        }
+    }
 /// The arguments used by the `terminate-enclave` command.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TerminateEnclavesArgs {

--- a/src/common/commands_parser.rs
+++ b/src/common/commands_parser.rs
@@ -1316,4 +1316,38 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "non_existing_config.json");
     }
+    #[test]
+    fn test_cannot_specify_both_uri_and_version(){
+        let app = create_app!();
+        let args = vec![
+            "nitro-cli",
+            "fetch-blobs",
+            "--URI",
+            "http://example.com",
+            "--version",
+            "2.2"
+        ];
+        let matches = app.try_get_matches_from(args);
+        let result = FetchBlobsArgs::new_with(matches
+            .as_ref()
+            .unwrap()
+            .subcommand_matches("fetch-blobs")
+            .unwrap());
+        assert!(result.is_err());
+    }
+    #[test]
+    fn test_must_provide_either_uri_or_version(){
+        let app = create_app!();
+        let args = vec![
+            "nitro-cli",
+            "fetch-blobs",
+        ];
+        let matches = app.try_get_matches_from(args);
+        let result = FetchBlobsArgs::new_with(matches
+            .as_ref()
+            .unwrap()
+            .subcommand_matches("fetch-blobs")
+            .unwrap());
+        assert!(result.is_err());
+    }
 }

--- a/src/common/commands_parser.rs
+++ b/src/common/commands_parser.rs
@@ -161,10 +161,7 @@ impl BuildEnclavesArgs {
             download_dir: Option<String>,
         },
         ///If user does not provide URI or version it will pull the latest from our default storage.
-        Latest{
-            /// User provided download directory
-            download_dir: Option<String>,
-        }
+        Latest(Option<String>),
     }
     impl FetchBlobsArgs {
         /// Creating and matching arguments for `fetch-blobs` command.
@@ -182,9 +179,7 @@ impl BuildEnclavesArgs {
                     download_dir,
                 });
             }
-            Ok(FetchBlobsArgs::Latest{
-                download_dir,
-            })
+            Ok(FetchBlobsArgs::Latest(download_dir))
         }
     }
 /// The arguments used by the `terminate-enclave` command.

--- a/src/common/commands_parser.rs
+++ b/src/common/commands_parser.rs
@@ -154,12 +154,13 @@ impl BuildEnclavesArgs {
     impl FetchBlobsArgs {
         /// Creating and matching arguments for `fetch-blobs` command.
         pub fn new_with(args: &ArgMatches) -> NitroCliResult<Self> {
-            match (args.get_one::<String>("URI"), args.get_one::<String>("version")) {
-                (Some(uri), None) => Ok(FetchBlobsArgs::Uri(uri.to_string())),
-                (None, Some(version)) => Ok(FetchBlobsArgs::Version(version.to_string())),
-                (Some(_), Some(_)) => Err(new_nitro_cli_failure!("Cannot specify both uri and version",NitroCliErrorEnum::ConflictingArgument)),
-                (None, None) => Err(new_nitro_cli_failure!("Either uri or version must be provided",NitroCliErrorEnum::MissingArgument)),
+            if let Some(uri) = args.get_one::<String>("URI") {
+                return Ok(FetchBlobsArgs::Uri(uri.to_string()));
             }
+            if let Some(version) = args.get_one::<String>("version") {
+                return Ok(FetchBlobsArgs::Version(version.to_string()));
+            }
+            Err( new_nitro_cli_failure!("Invalid arguments provided",NitroCliErrorEnum::MissingArgument))
         }
     }
 /// The arguments used by the `terminate-enclave` command.

--- a/src/common/commands_parser.rs
+++ b/src/common/commands_parser.rs
@@ -114,6 +114,8 @@ pub struct BuildEnclavesArgs {
     pub img_version: Option<String>,
     /// The path to custom metadata JSON file
     pub metadata: Option<String>,
+    /// The name of binary set
+    pub blobs_name: Option<String>,
 }
 
 impl BuildEnclavesArgs {
@@ -140,6 +142,7 @@ impl BuildEnclavesArgs {
             img_name: parse_image_name(args),
             img_version: parse_image_version(args),
             metadata: parse_metadata(args),
+            blobs_name: parse_blobs_name(args),
         })
     }
 }
@@ -570,6 +573,9 @@ fn parse_image_version(args: &ArgMatches) -> Option<String> {
 
 fn parse_metadata(args: &ArgMatches) -> Option<String> {
     args.get_one::<String>("metadata").map(String::from)
+}
+fn parse_blobs_name(args: &ArgMatches) -> Option<String> {
+    args.get_one::<String>("blobs-name").map(String::from)
 }
 
 fn parse_error_code_str(args: &ArgMatches) -> NitroCliResult<String> {

--- a/src/common/commands_parser.rs
+++ b/src/common/commands_parser.rs
@@ -1342,38 +1342,4 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "non_existing_config.json");
     }
-    #[test]
-    fn test_cannot_specify_both_uri_and_version(){
-        let app = create_app!();
-        let args = vec![
-            "nitro-cli",
-            "fetch-blobs",
-            "--URI",
-            "http://example.com",
-            "--version",
-            "2.2"
-        ];
-        let matches = app.try_get_matches_from(args);
-        let result = FetchBlobsArgs::new_with(matches
-            .as_ref()
-            .unwrap()
-            .subcommand_matches("fetch-blobs")
-            .unwrap());
-        assert!(result.is_err());
-    }
-    #[test]
-    fn test_must_provide_either_uri_or_version(){
-        let app = create_app!();
-        let args = vec![
-            "nitro-cli",
-            "fetch-blobs",
-        ];
-        let matches = app.try_get_matches_from(args);
-        let result = FetchBlobsArgs::new_with(matches
-            .as_ref()
-            .unwrap()
-            .subcommand_matches("fetch-blobs")
-            .unwrap());
-        assert!(result.is_err());
-    }
 }

--- a/src/common/commands_parser.rs
+++ b/src/common/commands_parser.rs
@@ -150,36 +150,36 @@ impl BuildEnclavesArgs {
         Uri {
             /// The URI of users binary storage.
             uri: String,
-            /// User provided download directory
-            download_dir: Option<String>,
+            /// The name of binary set
+            name: String,
         },
         ///Users can provide a version number that nitro-cli can fetch from default S3 bucket and if download_dir provided it will store them in there
         Version {
             /// The version number of requested blobs.
             version: String,
-            /// User provided download directory
-            download_dir: Option<String>,
+            /// The name of binary set
+            name: String,
         },
-        ///If user does not provide URI or version it will pull the latest from our default storage.
-        Latest(Option<String>),
     }
     impl FetchBlobsArgs {
         /// Creating and matching arguments for `fetch-blobs` command.
         pub fn new_with(args: &ArgMatches) -> NitroCliResult<Self> {
-            let download_dir = args.get_one::<String>("download-dir").map(|s| s.to_string());
+            let name = args.get_one::<String>("blobs-name")
+                .ok_or(new_nitro_cli_failure!("Name of binary set must be provided",NitroCliErrorEnum::InvalidArgument))
+                .map(|s| s.to_string())?;
             if let Some(uri) = args.get_one::<String>("URI") {
                 return Ok(FetchBlobsArgs::Uri {
                     uri: uri.to_string(),
-                    download_dir,
+                    name,
                 });
             }
             if let Some(version) = args.get_one::<String>("version") {
                 return Ok(FetchBlobsArgs::Version {
                     version: version.to_string(),
-                    download_dir,
+                    name,
                 });
             }
-            Ok(FetchBlobsArgs::Latest(download_dir))
+            Err( new_nitro_cli_failure!("Invalid arguments provided",NitroCliErrorEnum::MissingArgument))
         }
     }
 /// The arguments used by the `terminate-enclave` command.

--- a/src/common/commands_parser.rs
+++ b/src/common/commands_parser.rs
@@ -160,24 +160,31 @@ impl BuildEnclavesArgs {
             /// User provided download directory
             download_dir: Option<String>,
         },
+        ///If user does not provide URI or version it will pull the latest from our default storage.
+        Latest{
+            /// User provided download directory
+            download_dir: Option<String>,
+        }
     }
     impl FetchBlobsArgs {
         /// Creating and matching arguments for `fetch-blobs` command.
         pub fn new_with(args: &ArgMatches) -> NitroCliResult<Self> {
             let download_dir = args.get_one::<String>("download-dir").map(|s| s.to_string());
-        if let Some(uri) = args.get_one::<String>("URI") {
-            return Ok(FetchBlobsArgs::Uri {
-                uri: uri.to_string(),
+            if let Some(uri) = args.get_one::<String>("URI") {
+                return Ok(FetchBlobsArgs::Uri {
+                    uri: uri.to_string(),
+                    download_dir,
+                });
+            }
+            if let Some(version) = args.get_one::<String>("version") {
+                return Ok(FetchBlobsArgs::Version {
+                    version: version.to_string(),
+                    download_dir,
+                });
+            }
+            Ok(FetchBlobsArgs::Latest{
                 download_dir,
-            });
-        }
-        if let Some(version) = args.get_one::<String>("version") {
-            return Ok(FetchBlobsArgs::Version {
-                version: version.to_string(),
-                download_dir,
-            });
-        }
-            Err( new_nitro_cli_failure!("Invalid arguments provided",NitroCliErrorEnum::MissingArgument))
+            })
         }
     }
 /// The arguments used by the `terminate-enclave` command.

--- a/src/common/commands_parser.rs
+++ b/src/common/commands_parser.rs
@@ -146,20 +146,37 @@ impl BuildEnclavesArgs {
 /// The arguments used by the `fetch-blobs` command.
 #[derive(Debug)]
     pub enum FetchBlobsArgs {
-        /// The URI of users binary storage.
-        Uri(String),
-        /// The version number of requested blobs.
-        Version(String),
+        ///Users can provide a URI that nitro-cli can fetch and if download_dir provided it will store them in there
+        Uri {
+            /// The URI of users binary storage.
+            uri: String,
+            /// User provided download directory
+            download_dir: Option<String>,
+        },
+        ///Users can provide a version number that nitro-cli can fetch from default S3 bucket and if download_dir provided it will store them in there
+        Version {
+            /// The version number of requested blobs.
+            version: String,
+            /// User provided download directory
+            download_dir: Option<String>,
+        },
     }
     impl FetchBlobsArgs {
         /// Creating and matching arguments for `fetch-blobs` command.
         pub fn new_with(args: &ArgMatches) -> NitroCliResult<Self> {
-            if let Some(uri) = args.get_one::<String>("URI") {
-                return Ok(FetchBlobsArgs::Uri(uri.to_string()));
-            }
-            if let Some(version) = args.get_one::<String>("version") {
-                return Ok(FetchBlobsArgs::Version(version.to_string()));
-            }
+            let download_dir = args.get_one::<String>("download-dir").map(|s| s.to_string());
+        if let Some(uri) = args.get_one::<String>("URI") {
+            return Ok(FetchBlobsArgs::Uri {
+                uri: uri.to_string(),
+                download_dir,
+            });
+        }
+        if let Some(version) = args.get_one::<String>("version") {
+            return Ok(FetchBlobsArgs::Version {
+                version: version.to_string(),
+                download_dir,
+            });
+        }
             Err( new_nitro_cli_failure!("Invalid arguments provided",NitroCliErrorEnum::MissingArgument))
         }
     }

--- a/src/common/json_output.rs
+++ b/src/common/json_output.rs
@@ -260,3 +260,11 @@ impl MetadataDescribeInfo {
         }
     }
 }
+/// Metadata to inform users about the binaries they fetched.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct EnclaveBlobsMetadata {
+    ///Download uri of the blobs
+    pub source: String,
+    ///Download date of the blobs
+    pub date: String,
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -179,6 +179,8 @@ pub enum NitroCliErrorEnum {
     EnclaveNamingError,
     /// Signature checker error
     EIFSignatureCheckerError,
+    ///Blob fetch mechanism error
+    BlobFetcherError,
 }
 
 impl Eq for NitroCliErrorEnum {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -659,6 +659,42 @@ async fn fetch_from_uri(uri: String) -> NitroCliResult<PathBuf> {
             });
             Ok(PathBuf::from(BLOBS_DOWNLOAD_PATH))
         }
+        "http" | "https" => {
+            let arch_url = uri.trim_end_matches('/');
+            let response = reqwest::get(arch_url)
+                .await
+                .map_err(|e| {
+                    new_nitro_cli_failure!(&format!("Failed to download from HTTP: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+                }).ok_or_exit_with_errno(None);
+            let bytes = response.bytes()
+                .await
+                .map_err(|e| {
+                    new_nitro_cli_failure!(&format!("Failed to read response body: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+                }).ok_or_exit_with_errno(None);
+
+            let xz = XzDecoder::new(&bytes[..]);
+            let mut archive = tar::Archive::new(xz);
+            
+            let arch_path = find_arch();
+            archive.entries()
+                .map_err(|e| {
+                    new_nitro_cli_failure!(&format!("Failed to read archive entries: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+                }).ok_or_exit_with_errno(None)
+                .filter_map(|e| e.ok())
+                .filter(|e| {
+                    e.path().map(|p| {
+                        let path_str = p.to_string_lossy();
+                        path_str.starts_with(&format!("enclaves-blobs/{arch_path}")) && !path_str.ends_with("/")
+                    }).unwrap_or(false)
+                })
+                .for_each(|mut entry| {
+                    let path = entry.path().unwrap();
+                    let file_name = path.file_name().unwrap();
+                    let target_path = Path::new(BLOBS_DOWNLOAD_PATH).join(file_name);
+                    let _ = entry.unpack(&target_path);
+                });
+            Ok(PathBuf::from(BLOBS_DOWNLOAD_PATH))
+        },
         _ => {
             Err(new_nitro_cli_failure!("Unsupported URI scheme", NitroCliErrorEnum::BlobFetcherError))
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -587,21 +587,14 @@ pub fn get_file_pcr(path: String, pcr_type: PcrType) -> NitroCliResult<BTreeMap<
 ///Binary fetching mechanism for `fetch-blobs` subcommand.
 pub async fn fetch_binaries(arg: FetchBlobsArgs){
     match arg {
-        FetchBlobsArgs::Uri{uri, download_dir} => {
-            fetch_from_uri(uri,download_dir).await.map_err(|e|{
+        FetchBlobsArgs::Uri{uri, name} => {
+            fetch_from_uri(uri,name).await.map_err(|e|{
                 new_nitro_cli_failure!(&format!("Could not fetch from uri: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
             }).ok_or_exit_with_errno(None);
         }
-        FetchBlobsArgs::Version{version,download_dir}=> {
+        FetchBlobsArgs::Version{version,name}=> {
             let base_prefix = format!("s3://{DEFAULT_S3_BUCKET}/{version}/enclaves-blobs.txz");
-            fetch_from_uri(base_prefix,download_dir).await
-            .map_err(|e|{
-                new_nitro_cli_failure!(&format!("Version mismatch: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-            }).ok_or_exit_with_errno(None);
-        }
-        FetchBlobsArgs::Latest(download_dir) => {
-            let base_prefix = format!("s3://{DEFAULT_S3_BUCKET}/latest/enclaves-blobs.txz");
-            fetch_from_uri(base_prefix,download_dir).await
+            fetch_from_uri(base_prefix,name).await
             .map_err(|e|{
                 new_nitro_cli_failure!(&format!("Version mismatch: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
             }).ok_or_exit_with_errno(None);
@@ -687,16 +680,15 @@ pub async fn list_binaries() -> NitroCliResult<()>{//TODO! make output prettier
             Err(err) => return Err(new_nitro_cli_failure!(&format!("Could not list binaries. {:?}", err), NitroCliErrorEnum::BlobFetcherError)),
         }
     }
-    
     table.printstd();
     Ok(())
-
 }
-fn create_dir_for_binaries(download_dir: Option<String>) -> NitroCliResult<String>{
-    let output_dir = match download_dir {
-        Some(dir) => format!("{dir}/binaries/"),
-        None => BLOBS_DOWNLOAD_PATH.to_string(),
-    };
+fn create_dir_for_binaries(name: String) -> NitroCliResult<String>{
+    let output_dir = format!("{BLOBS_DOWNLOAD_PATH}/{name}/");
+    //TO:DO CHECK IF DIRECTORY EXIST
+    if Path::new(&output_dir).exists(){
+        return Err(new_nitro_cli_failure!(&format!("Provided name of the binary set is already exist."), NitroCliErrorEnum::BlobFetcherError));
+    }
     fs::create_dir_all(&output_dir).map_err(|e| {
         new_nitro_cli_failure!(&format!("Could not create download directory: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
     }).ok_or_exit_with_errno(None);
@@ -704,12 +696,12 @@ fn create_dir_for_binaries(download_dir: Option<String>) -> NitroCliResult<Strin
     Ok(output_dir)
 }
 /// Fetching from specific URI that user provided.
-async fn fetch_from_uri(uri: String, download_dir : Option<String>) -> NitroCliResult<()> {
+async fn fetch_from_uri(uri: String, name : String) -> NitroCliResult<()> {
     let url = Url::parse(&uri).map_err(|e| {
         new_nitro_cli_failure!(&format!("Could not read the provided URI: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
     }).ok_or_exit_with_errno(None);
 
-    let output_dir = create_dir_for_binaries(download_dir).map_err(|e| {
+    let output_dir = create_dir_for_binaries(name).map_err(|e| {
         new_nitro_cli_failure!(&format!("Could not read the provided URI: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
     }).ok_or_exit_with_errno(None);
 
@@ -957,12 +949,14 @@ macro_rules! create_app {
                             .long("list")
                             .action(clap::ArgAction::SetTrue)
                             .help("The flag for listing default s3 bucket which contains pre-built binaries.")
-                            .conflicts_with_all(["URI","version","download-dir"])
+                            .conflicts_with_all(["URI","version","blobs-name"])
                         )
                     .arg(
-                        Arg::new("download-dir")
-                            .long("download-dir")
-                            .help("User specified download directory. In case user want to use multiple versions of binaries.")
+                        Arg::new("blobs-name")
+                            .long("blobs-name")
+                            .help("Name of the binary set. Provided by the user")
+                            .requires("URI")
+                            .requires("version")
                             .conflicts_with("list")
                     )
             )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -587,21 +587,22 @@ pub fn get_file_pcr(path: String, pcr_type: PcrType) -> NitroCliResult<BTreeMap<
 ///Binary fetching mechanism for `fetch-blobs` subcommand.
 pub async fn fetch_binaries(arg: FetchBlobsArgs){
     match arg {
-        FetchBlobsArgs::Uri(uri) => {
-            fetch_from_uri(uri).await.map_err(|e|{
+        FetchBlobsArgs::Uri{uri, download_dir} => {
+            fetch_from_uri(uri,download_dir).await.map_err(|e|{
                 new_nitro_cli_failure!(&format!("Could not fetch from uri: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
             }).ok_or_exit_with_errno(None);
         }
-        FetchBlobsArgs::Version(version) => {
+        FetchBlobsArgs::Version{version,download_dir}=> {
             let base_prefix = format!("s3://{DEFAULT_S3_BUCKET}/{version}/enclaves-blobs.txz");
-            fetch_from_uri(base_prefix).await
+            fetch_from_uri(base_prefix,download_dir).await
             .map_err(|e|{
                 new_nitro_cli_failure!(&format!("Version mismatch: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
             }).ok_or_exit_with_errno(None);
         }
     }
 }
-fn unpack_blob_archive(data: bytes::Bytes) -> NitroCliResult<()>{
+fn unpack_blob_archive(data: bytes::Bytes, download_dir : String) -> NitroCliResult<()>{
+
     let xz = XzDecoder::new(&data[..]);
     let mut archive = tar::Archive::new(xz);
     
@@ -619,11 +620,11 @@ fn unpack_blob_archive(data: bytes::Bytes) -> NitroCliResult<()>{
     .for_each(|mut entry| {
         let path = entry.path().unwrap();
         let file_name = path.file_name().unwrap();
-        let target_path = Path::new(BLOBS_DOWNLOAD_PATH).join(file_name);
+        let target_path = Path::new(&download_dir).join(file_name);
         let _ = entry.unpack(&target_path);
     });
 
-    fs::set_permissions(format!("{BLOBS_DOWNLOAD_PATH}/linuxkit",), fs::Permissions::from_mode(0o755))
+    fs::set_permissions(format!("{download_dir}/linuxkit",), fs::Permissions::from_mode(0o755))
         .map_err(|e| {
             new_nitro_cli_failure!(&format!("Could not set executable permissions: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
         }).ok_or_exit_with_errno(None);
@@ -684,14 +685,25 @@ pub async fn list_binaries() -> NitroCliResult<()>{//TODO! make output prettier
     Ok(())
 
 }
+fn create_dir_for_binaries(download_dir: Option<String>) -> NitroCliResult<String>{
+    let output_dir = match download_dir {
+        Some(dir) => format!("{dir}/binaries/"),
+        None => BLOBS_DOWNLOAD_PATH.to_string(),
+    };
+    fs::create_dir_all(&output_dir).map_err(|e| {
+        new_nitro_cli_failure!(&format!("Could not create download directory: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+    }).ok_or_exit_with_errno(None);
+
+    Ok(output_dir)
+}
 /// Fetching from specific URI that user provided.
-async fn fetch_from_uri(uri: String) -> NitroCliResult<()> {
+async fn fetch_from_uri(uri: String, download_dir : Option<String>) -> NitroCliResult<()> {
     let url = Url::parse(&uri).map_err(|e| {
         new_nitro_cli_failure!(&format!("Could not read the provided URI: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
     }).ok_or_exit_with_errno(None);
 
-    fs::create_dir_all(BLOBS_DOWNLOAD_PATH).map_err(|e| {
-        new_nitro_cli_failure!(&format!("Could not create download directory: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+    let output_dir = create_dir_for_binaries(download_dir).map_err(|e| {
+        new_nitro_cli_failure!(&format!("Could not read the provided URI: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
     }).ok_or_exit_with_errno(None);
 
     match url.scheme() {
@@ -717,7 +729,7 @@ async fn fetch_from_uri(uri: String) -> NitroCliResult<()> {
                 }).ok_or_exit_with_errno(None);
             let data = bytes.into_bytes();
             
-            unpack_blob_archive(data)
+            unpack_blob_archive(data,output_dir)
                 .map_err(|e| {
                     new_nitro_cli_failure!(&format!("Could not unpack blob archive: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
                 }).ok_or_exit_with_errno(None);
@@ -737,7 +749,7 @@ async fn fetch_from_uri(uri: String) -> NitroCliResult<()> {
                     new_nitro_cli_failure!(&format!("Failed to read response body: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
                 }).ok_or_exit_with_errno(None);
             
-            unpack_blob_archive(bytes)
+            unpack_blob_archive(bytes,output_dir)
                 .map_err(|e| {
                     new_nitro_cli_failure!(&format!("Could not unpack blob archive: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
                 }).ok_or_exit_with_errno(None);
@@ -932,9 +944,18 @@ macro_rules! create_app {
                             .long("list")
                             .action(clap::ArgAction::SetTrue)
                             .help("The flag for listing default s3 bucket which contains pre-built binaries.")
-                            .required_unless_present_any(["URI","version"])
-                            .conflicts_with_all(["URI","version"])
+                            .required_unless_present_any(["URI","version","download-dir"])
+                            .conflicts_with_all(["URI","version","download-dir"])
                         )
+                    .arg(
+                        Arg::new("download-dir")
+                            .long("download-dir")
+                            .help("User specified download directory. In case user want to use multiple versions of binaries.")
+                            .conflicts_with("list")
+                            .required_unless_present("list")
+                            .requires("URI")
+                            .requires("version")
+                    )
             )
             .subcommand(
                 Command::new("describe-eif")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -615,7 +615,8 @@ fn clear_dir_on_fail(name: String) -> NitroCliResult<()>{
     })?;
     Ok(())
 } 
-fn unpack_blob_archive(data: bytes::Bytes, download_dir : &String) -> NitroCliResult<()>{
+///Unpack the binaries based on architecture
+pub fn unpack_blob_archive(data: bytes::Bytes, download_dir : &String) -> NitroCliResult<()>{
 
     let xz = XzDecoder::new(&data[..]);
     let mut archive = tar::Archive::new(xz);
@@ -773,7 +774,8 @@ async fn fetch_from_uri(uri: String, name : String) -> NitroCliResult<()> {
         }
     }
 }
-async fn fetch_from_s3(url: Url) -> NitroCliResult<bytes::Bytes>{
+/// Fetches binaries from provided s3 uri.
+pub async fn fetch_from_s3(url: Url) -> NitroCliResult<bytes::Bytes>{
     let bucket = url.host_str().ok_or("No bucket specified").unwrap();
     let prefix = url.path().trim_start_matches('/');  // "releases/1.3/"
     let config = aws_config::from_env().load().await;
@@ -796,14 +798,21 @@ async fn fetch_from_s3(url: Url) -> NitroCliResult<bytes::Bytes>{
 
     Ok(bytes.into_bytes())
 }
-
-async fn fetch_from_http(uri: &String) -> NitroCliResult<bytes::Bytes>{
+/// Fetches binaries from provided uri but uri must be http.
+pub async fn fetch_from_http(uri: &String) -> NitroCliResult<bytes::Bytes>{
     let url = uri.trim_end_matches('/');
     let response = reqwest::get(url)
         .await
         .map_err(|e| {
             new_nitro_cli_failure!(&format!("Failed to download from HTTP: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
         })?;
+    // Check status code
+    if !response.status().is_success() {
+        return Err(new_nitro_cli_failure!(
+            &format!("HTTP request failed with status: {}", response.status()),
+            NitroCliErrorEnum::BlobFetcherError
+        ));
+    }
     let bytes = response.bytes()
         .await
         .map_err(|e| {
@@ -812,7 +821,8 @@ async fn fetch_from_http(uri: &String) -> NitroCliResult<bytes::Bytes>{
 
     Ok(bytes)
 }
-fn create_blobs_metadata(uri: String,output_dir: String) -> NitroCliResult<()>{
+/// Creates a metadata for binaries.
+pub fn create_blobs_metadata(uri: String,output_dir: String) -> NitroCliResult<()>{
     let metadata = EnclaveBlobsMetadata {
         source: uri,
         date: Utc::now().to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -599,7 +599,7 @@ pub async fn fetch_binaries(arg: FetchBlobsArgs){
                 new_nitro_cli_failure!(&format!("Version mismatch: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
             }).ok_or_exit_with_errno(None);
         }
-        FetchBlobsArgs::Latest{download_dir} => {
+        FetchBlobsArgs::Latest(download_dir) => {
             let base_prefix = format!("s3://{DEFAULT_S3_BUCKET}/latest/enclaves-blobs.txz");
             fetch_from_uri(base_prefix,download_dir).await
             .map_err(|e|{
@@ -715,27 +715,8 @@ async fn fetch_from_uri(uri: String, download_dir : Option<String>) -> NitroCliR
 
     match url.scheme() {
         "s3" => {
-            let bucket = url.host_str().ok_or("No bucket specified").unwrap();
-            let prefix = url.path().trim_start_matches('/');  // "releases/1.3/"
-            let config = aws_config::from_env().load().await;
-            let client = Client::new(&config);
+            let data = fetch_from_s3(url).await;
 
-            let resp = client
-                .get_object()
-                .bucket(bucket)
-                .key(prefix)
-                .send()
-                .await
-                .map_err(|e| {
-                    new_nitro_cli_failure!(&format!("Could not fetch from s3 URI {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-                }).ok_or_exit_with_errno(None);
-
-            let bytes = resp.body.collect().await
-                .map_err(|e| {
-                    new_nitro_cli_failure!(&format!("Could not read s3 storage: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-                }).ok_or_exit_with_errno(None);
-            let data = bytes.into_bytes();
-            
             unpack_blob_archive(data,output_dir)
                 .map_err(|e| {
                     new_nitro_cli_failure!(&format!("Could not unpack blob archive: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
@@ -744,18 +725,8 @@ async fn fetch_from_uri(uri: String, download_dir : Option<String>) -> NitroCliR
             Ok(())
         }
         "http" | "https" => {
-            let url = uri.trim_end_matches('/');
-            let response = reqwest::get(url)
-                .await
-                .map_err(|e| {
-                    new_nitro_cli_failure!(&format!("Failed to download from HTTP: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-                }).ok_or_exit_with_errno(None);
-            let bytes = response.bytes()
-                .await
-                .map_err(|e| {
-                    new_nitro_cli_failure!(&format!("Failed to read response body: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-                }).ok_or_exit_with_errno(None);
             
+            let bytes = fetch_from_http(uri).await;
             unpack_blob_archive(bytes,output_dir)
                 .map_err(|e| {
                     new_nitro_cli_failure!(&format!("Could not unpack blob archive: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
@@ -767,8 +738,45 @@ async fn fetch_from_uri(uri: String, download_dir : Option<String>) -> NitroCliR
         }
     }
 }
+async fn fetch_from_s3(url: Url) -> bytes::Bytes{
+    let bucket = url.host_str().ok_or("No bucket specified").unwrap();
+    let prefix = url.path().trim_start_matches('/');  // "releases/1.3/"
+    let config = aws_config::from_env().load().await;
+    let client = Client::new(&config);
 
+    let resp = client
+        .get_object()
+        .bucket(bucket)
+        .key(prefix)
+        .send()
+        .await
+        .map_err(|e| {
+            new_nitro_cli_failure!(&format!("Could not fetch from s3 URI {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+        }).ok_or_exit_with_errno(None);
 
+    let bytes = resp.body.collect().await
+        .map_err(|e| {
+            new_nitro_cli_failure!(&format!("Could not read s3 storage: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+        }).ok_or_exit_with_errno(None);
+
+    bytes.into_bytes()
+}
+
+async fn fetch_from_http(uri: String) -> bytes::Bytes{
+    let url = uri.trim_end_matches('/');
+    let response = reqwest::get(url)
+        .await
+        .map_err(|e| {
+            new_nitro_cli_failure!(&format!("Failed to download from HTTP: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+        }).ok_or_exit_with_errno(None);
+    let bytes = response.bytes()
+        .await
+        .map_err(|e| {
+            new_nitro_cli_failure!(&format!("Failed to read response body: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+        }).ok_or_exit_with_errno(None);
+
+    bytes
+}
 
 /// Macro defining the arguments configuration for a *Nitro CLI* application.
 #[macro_export]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ use std::io::{self, Read, Write};
 use std::os::unix::net::UnixStream;
 use std::path::{PathBuf,Path};
 use url::Url;
+use std::os::unix::fs::PermissionsExt; 
 use aws_sdk_s3::Client;
 use xz2::read::XzDecoder; 
 use std::env::consts::ARCH;
@@ -588,7 +589,7 @@ pub async fn fetch_binaries(arg: FetchBlobsArgs){
             }).ok_or_exit_with_errno(None);
         }
         FetchBlobsArgs::Version(version) => {
-            let base_prefix = format!("s3://nitro-binaries-test/releases/{version}/");
+            let base_prefix = format!("s3://nitro-binaries-test/releases/{version}/enclaves-blobs.txz");
             fetch_from_uri(base_prefix).await
             .map_err(|e|{
                 new_nitro_cli_failure!(&format!("Version mismatch: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
@@ -600,11 +601,41 @@ fn find_arch() -> &'static str {
     match ARCH {
         "x86_64" => "build-X64/x86_64",
         "aarch64" => "build-ARM64/aarch64",
-        _ => ".",
+        _ => ".",//TO:DO!
     }
 }
+fn unpack_blob_archive(data: bytes::Bytes) -> NitroCliResult<()>{
+    let xz = XzDecoder::new(&data[..]);
+    let mut archive = tar::Archive::new(xz);
+    
+    let arch_path = find_arch();
+
+    archive.entries()
+    .map_err(|e| {
+        new_nitro_cli_failure!(&format!("Failed to read archive entries: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+    }).ok_or_exit_with_errno(None)
+    .filter_map(|e| e.ok())
+    .filter(|e| {
+        e.path().map(|p| {
+            let path_str = p.to_string_lossy();
+            path_str.starts_with(&format!("enclaves-blobs/{arch_path}")) && !path_str.ends_with("/")
+        }).unwrap_or(false)
+    })
+    .for_each(|mut entry| {
+        let path = entry.path().unwrap();
+        let file_name = path.file_name().unwrap();
+        let target_path = Path::new(BLOBS_DOWNLOAD_PATH).join(file_name);
+        let _ = entry.unpack(&target_path);
+    });
+
+    fs::set_permissions(format!("{BLOBS_DOWNLOAD_PATH}/linuxkit",), fs::Permissions::from_mode(0o755))
+        .map_err(|e| {
+            new_nitro_cli_failure!(&format!("Could not set executable permissions: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+        }).ok_or_exit_with_errno(None);
+    Ok(())
+}
 /// Fetching from specific URI that user provided.
-async fn fetch_from_uri(uri: String) -> NitroCliResult<PathBuf> {
+async fn fetch_from_uri(uri: String) -> NitroCliResult<()> {
     let url = Url::parse(&uri).map_err(|e| {
         new_nitro_cli_failure!(&format!("Could not read the provided URI: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
     }).ok_or_exit_with_errno(None);
@@ -635,33 +666,17 @@ async fn fetch_from_uri(uri: String) -> NitroCliResult<PathBuf> {
                     new_nitro_cli_failure!(&format!("Could not read s3 storage: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
                 }).ok_or_exit_with_errno(None);
             let data = bytes.into_bytes();
-            let xz = XzDecoder::new(&data[..]);
-            let mut archive = tar::Archive::new(xz);
             
-            let arch_path = find_arch();
+            unpack_blob_archive(data)
+                .map_err(|e| {
+                    new_nitro_cli_failure!(&format!("Could not unpack blob archive: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+                }).ok_or_exit_with_errno(None);
 
-            archive.entries()
-            .map_err(|e| {
-                new_nitro_cli_failure!(&format!("Failed to read archive entries: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-            }).ok_or_exit_with_errno(None)
-            .filter_map(|e| e.ok())
-            .filter(|e| {
-                e.path().map(|p| {
-                    let path_str = p.to_string_lossy();
-                    path_str.starts_with(&format!("enclaves-blobs/{arch_path}")) && !path_str.ends_with("/")
-                }).unwrap_or(false)
-            })
-            .for_each(|mut entry| {
-                let path = entry.path().unwrap();
-                let file_name = path.file_name().unwrap();
-                let target_path = Path::new(BLOBS_DOWNLOAD_PATH).join(file_name);
-                let _ = entry.unpack(&target_path);
-            });
-            Ok(PathBuf::from(BLOBS_DOWNLOAD_PATH))
+            Ok(())
         }
         "http" | "https" => {
-            let arch_url = uri.trim_end_matches('/');
-            let response = reqwest::get(arch_url)
+            let url = uri.trim_end_matches('/');
+            let response = reqwest::get(url)
                 .await
                 .map_err(|e| {
                     new_nitro_cli_failure!(&format!("Failed to download from HTTP: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
@@ -671,29 +686,12 @@ async fn fetch_from_uri(uri: String) -> NitroCliResult<PathBuf> {
                 .map_err(|e| {
                     new_nitro_cli_failure!(&format!("Failed to read response body: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
                 }).ok_or_exit_with_errno(None);
-
-            let xz = XzDecoder::new(&bytes[..]);
-            let mut archive = tar::Archive::new(xz);
             
-            let arch_path = find_arch();
-            archive.entries()
+            unpack_blob_archive(bytes)
                 .map_err(|e| {
-                    new_nitro_cli_failure!(&format!("Failed to read archive entries: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-                }).ok_or_exit_with_errno(None)
-                .filter_map(|e| e.ok())
-                .filter(|e| {
-                    e.path().map(|p| {
-                        let path_str = p.to_string_lossy();
-                        path_str.starts_with(&format!("enclaves-blobs/{arch_path}")) && !path_str.ends_with("/")
-                    }).unwrap_or(false)
-                })
-                .for_each(|mut entry| {
-                    let path = entry.path().unwrap();
-                    let file_name = path.file_name().unwrap();
-                    let target_path = Path::new(BLOBS_DOWNLOAD_PATH).join(file_name);
-                    let _ = entry.unpack(&target_path);
-                });
-            Ok(PathBuf::from(BLOBS_DOWNLOAD_PATH))
+                    new_nitro_cli_failure!(&format!("Could not unpack blob archive: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+                }).ok_or_exit_with_errno(None);
+            Ok(())
         },
         _ => {
             Err(new_nitro_cli_failure!("Unsupported URI scheme", NitroCliErrorEnum::BlobFetcherError))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,10 @@ use std::os::unix::net::UnixStream;
 use std::path::{PathBuf,Path};
 use url::Url;
 use std::os::unix::fs::PermissionsExt; 
-use aws_sdk_s3::Client;
+use futures_util::stream::StreamExt;
+use aws_sdk_s3::{Client,primitives::DateTimeFormat};
+use prettytable::{Table, row};
+use byte_unit::Byte;
 use xz2::read::XzDecoder; 
 use std::env::consts::ARCH;
 use common::commands_parser::{BuildEnclavesArgs, EmptyArgs, FetchBlobsArgs, RunEnclavesArgs};
@@ -53,7 +56,8 @@ pub const CID_TO_CONSOLE_PORT_OFFSET: u32 = 10000;
 const DEFAULT_BLOBS_PATH: &str = "/usr/share/nitro_enclaves/blobs/";
 /// Download path to be used to fetch binaries with `fetch-blobs` subcommand.
 const BLOBS_DOWNLOAD_PATH: &str = "/var/lib/nitro-cli/binaries";
-
+///Default S3 bucket which stores pre-built binaries.
+const DEFAULT_S3_BUCKET: &str = "nitro-binaries-test";
 /// Build an enclave image file with the provided arguments.
 pub fn build_enclaves(args: BuildEnclavesArgs) -> NitroCliResult<()> {
     debug!("build_enclaves");
@@ -589,7 +593,7 @@ pub async fn fetch_binaries(arg: FetchBlobsArgs){
             }).ok_or_exit_with_errno(None);
         }
         FetchBlobsArgs::Version(version) => {
-            let base_prefix = format!("s3://nitro-binaries-test/{version}/enclaves-blobs.txz");
+            let base_prefix = format!("s3://{DEFAULT_S3_BUCKET}/{version}/enclaves-blobs.txz");
             fetch_from_uri(base_prefix).await
             .map_err(|e|{
                 new_nitro_cli_failure!(&format!("Version mismatch: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
@@ -624,6 +628,61 @@ fn unpack_blob_archive(data: bytes::Bytes) -> NitroCliResult<()>{
             new_nitro_cli_failure!(&format!("Could not set executable permissions: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
         }).ok_or_exit_with_errno(None);
     Ok(())
+}
+///Lists default s3 bucket that contains pre-built binaries.
+pub async fn list_binaries() -> NitroCliResult<()>{//TODO! make output prettier
+    let url = Url::parse(&format!("s3://{DEFAULT_S3_BUCKET}/")).map_err(|e| {
+        new_nitro_cli_failure!(&format!("Could not read the provided URI: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+    }).ok_or_exit_with_errno(None);
+    
+    let bucket = url.host_str().ok_or("No bucket specified").unwrap();
+    let config = aws_config::from_env().load().await;
+    let client = Client::new(&config);
+    
+    let mut table = Table::new();
+    table.add_row(row![bFg->"Version", bFg->"Size", bFg->"Last Modified", bFg->"URI"]);
+    
+    let mut response = client
+        .list_objects_v2()
+        .bucket(bucket.to_owned())
+        .into_paginator()
+        .send();
+    
+    while let Some(result) = response.next().await {
+        match result {
+            Ok(output) => {
+                if let Some(contents) = output.contents() { 
+                    for object in contents {
+                        let version = object.key()
+                            .and_then(|key| key.split('/').nth(0))
+                            .unwrap_or("unknown");
+    
+                        let size = Byte::from_bytes(object.size() as u128)
+                            .get_appropriate_unit(true)
+                            .to_string();
+    
+                            let last_modified = object.last_modified()
+                            .map(|dt| dt.fmt(DateTimeFormat::DateTime).unwrap_or_default())
+                            .unwrap_or_default();
+    
+                        let uri = format!("s3://{}/{}", bucket, object.key().unwrap_or_default());
+                        
+                        table.add_row(row![
+                            version,
+                            size,
+                            last_modified,
+                            uri
+                        ]);
+                    }
+                }
+            }
+            Err(err) => return Err(new_nitro_cli_failure!(&format!("Could not list binaries. {:?}", err), NitroCliErrorEnum::BlobFetcherError)),
+        }
+    }
+    
+    table.printstd();
+    Ok(())
+
 }
 /// Fetching from specific URI that user provided.
 async fn fetch_from_uri(uri: String) -> NitroCliResult<()> {
@@ -858,12 +917,24 @@ macro_rules! create_app {
                         Arg::new("version")
                             .long("version")
                             .help("Version tag of requested binary version.")
+                            .required_unless_present_any(["URI","list"])
+                            .conflicts_with_all(["URI","list"])
                     )
                     .arg(
                         Arg::new("URI")
                             .long("URI")
-                            .help("URI of your binary storage."),
-                    ),
+                            .help("URI of your binary storage.")
+                            .required_unless_present_any(["list","version"])
+                            .conflicts_with_all(["list","version"])
+                    )
+                    .arg(
+                        Arg::new("list")
+                            .long("list")
+                            .action(clap::ArgAction::SetTrue)
+                            .help("The flag for listing default s3 bucket which contains pre-built binaries.")
+                            .required_unless_present_any(["URI","version"])
+                            .conflicts_with_all(["URI","version"])
+                        )
             )
             .subcommand(
                 Command::new("describe-eif")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -589,7 +589,7 @@ pub async fn fetch_binaries(arg: FetchBlobsArgs){
             }).ok_or_exit_with_errno(None);
         }
         FetchBlobsArgs::Version(version) => {
-            let base_prefix = format!("s3://nitro-binaries-test/releases/{version}/enclaves-blobs.txz");
+            let base_prefix = format!("s3://nitro-binaries-test/{version}/enclaves-blobs.txz");
             fetch_from_uri(base_prefix).await
             .map_err(|e|{
                 new_nitro_cli_failure!(&format!("Version mismatch: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
@@ -597,19 +597,10 @@ pub async fn fetch_binaries(arg: FetchBlobsArgs){
         }
     }
 }
-fn find_arch() -> &'static str {
-    match ARCH {
-        "x86_64" => "build-X64/x86_64",
-        "aarch64" => "build-ARM64/aarch64",
-        _ => ".",//TO:DO!
-    }
-}
 fn unpack_blob_archive(data: bytes::Bytes) -> NitroCliResult<()>{
     let xz = XzDecoder::new(&data[..]);
     let mut archive = tar::Archive::new(xz);
     
-    let arch_path = find_arch();
-
     archive.entries()
     .map_err(|e| {
         new_nitro_cli_failure!(&format!("Failed to read archive entries: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
@@ -618,7 +609,7 @@ fn unpack_blob_archive(data: bytes::Bytes) -> NitroCliResult<()>{
     .filter(|e| {
         e.path().map(|p| {
             let path_str = p.to_string_lossy();
-            path_str.starts_with(&format!("enclaves-blobs/{arch_path}")) && !path_str.ends_with("/")
+            path_str.starts_with(&format!("{ARCH}")) && !path_str.ends_with("/")
         }).unwrap_or(false)
     })
     .for_each(|mut entry| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,9 +34,10 @@ use prettytable::{Table, row};
 use byte_unit::Byte;
 use xz2::read::XzDecoder; 
 use std::env::consts::ARCH;
+use chrono::Utc;
 use common::commands_parser::{BuildEnclavesArgs, EmptyArgs, FetchBlobsArgs, RunEnclavesArgs};
 use common::json_output::{
-    EifDescribeInfo, EnclaveBuildInfo, EnclaveTerminateInfo, MetadataDescribeInfo,
+    EifDescribeInfo, EnclaveBuildInfo, EnclaveTerminateInfo, MetadataDescribeInfo, EnclaveBlobsMetadata
 };
 use common::{enclave_proc_command_send_single, get_sockets_dir_path, ExitGracefully};
 use common::{EnclaveProcessCommandType, NitroCliErrorEnum, NitroCliFailure, NitroCliResult};
@@ -603,7 +604,7 @@ pub async fn fetch_binaries(arg: FetchBlobsArgs){
         }
     }
 }
-fn unpack_blob_archive(data: bytes::Bytes, download_dir : String) -> NitroCliResult<()>{
+fn unpack_blob_archive(data: bytes::Bytes, download_dir : &String) -> NitroCliResult<()>{
 
     let xz = XzDecoder::new(&data[..]);
     let mut archive = tar::Archive::new(xz);
@@ -630,6 +631,8 @@ fn unpack_blob_archive(data: bytes::Bytes, download_dir : String) -> NitroCliRes
         .map_err(|e| {
             new_nitro_cli_failure!(&format!("Could not set executable permissions: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
         }).ok_or_exit_with_errno(None);
+    
+
     Ok(())
 }
 ///Lists default s3 bucket that contains pre-built binaries.
@@ -711,20 +714,27 @@ async fn fetch_from_uri(uri: String, name : String) -> NitroCliResult<()> {
         "s3" => {
             let data = fetch_from_s3(url).await;
 
-            unpack_blob_archive(data,output_dir)
+            unpack_blob_archive(data,&output_dir)
                 .map_err(|e| {
                     new_nitro_cli_failure!(&format!("Could not unpack blob archive: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
                 }).ok_or_exit_with_errno(None);
+
+            create_blobs_metadata(uri, output_dir).map_err(|e| {
+                new_nitro_cli_failure!(&format!("Could not create metadata for fetched blobs: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+            }).ok_or_exit_with_errno(None);
 
             Ok(())
         }
         "http" | "https" => {
             
-            let bytes = fetch_from_http(uri).await;
-            unpack_blob_archive(bytes,output_dir)
+            let bytes = fetch_from_http(&uri).await;
+            unpack_blob_archive(bytes,&output_dir)
                 .map_err(|e| {
                     new_nitro_cli_failure!(&format!("Could not unpack blob archive: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
                 }).ok_or_exit_with_errno(None);
+            create_blobs_metadata(uri, output_dir).map_err(|e| {
+                new_nitro_cli_failure!(&format!("Could not create metadata for fetched blobs: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+            }).ok_or_exit_with_errno(None);
             Ok(())
         },
         _ => {
@@ -756,7 +766,7 @@ async fn fetch_from_s3(url: Url) -> bytes::Bytes{
     bytes.into_bytes()
 }
 
-async fn fetch_from_http(uri: String) -> bytes::Bytes{
+async fn fetch_from_http(uri: &String) -> bytes::Bytes{
     let url = uri.trim_end_matches('/');
     let response = reqwest::get(url)
         .await
@@ -771,7 +781,19 @@ async fn fetch_from_http(uri: String) -> bytes::Bytes{
 
     bytes
 }
-
+fn create_blobs_metadata(uri: String,output_dir: String) -> NitroCliResult<()>{
+    let metadata = EnclaveBlobsMetadata {
+        source: uri,
+        date: Utc::now().to_string(),
+    };
+    let json = serde_json::to_string_pretty(&metadata).map_err(|e| {
+        new_nitro_cli_failure!(&format!("Could not serialize metadata: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+        }).ok_or_exit_with_errno(None);
+    fs::write(format!("{output_dir}/.metadata.json"), json).map_err(|e| {
+        new_nitro_cli_failure!(&format!("Could not create metadata: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+        }).ok_or_exit_with_errno(None);
+    Ok(())
+}
 /// Macro defining the arguments configuration for a *Nitro CLI* application.
 #[macro_export]
 macro_rules! create_app {
@@ -943,12 +965,14 @@ macro_rules! create_app {
                         Arg::new("version")
                             .long("version")
                             .help("Version tag of requested binary version.")
+                            .requires("blobs-name")
                             .conflicts_with_all(["URI","list"])
                     )
                     .arg(
                         Arg::new("URI")
                             .long("URI")
-                            .help("URI of your binary storage.")
+                            .help("URI of remote binary storage.")
+                            .requires("blobs-name")
                             .conflicts_with_all(["list","version"])
                     )
                     .arg(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ pub fn build_enclaves(args: BuildEnclavesArgs) -> NitroCliResult<()> {
         &args.img_name,
         &args.img_version,
         &args.metadata,
+        args.blobs_name,
     )
     .map_err(|e| e.add_subaction("Failed to build EIF from docker".to_string()))?;
     Ok(())
@@ -86,9 +87,10 @@ pub fn build_from_docker(
     img_name: &Option<String>,
     img_version: &Option<String>,
     metadata_path: &Option<String>,
+    blobs_name: Option<String>,
 ) -> NitroCliResult<(File, BTreeMap<String, String>)> {
     let blobs_path =
-        blobs_path().map_err(|e| e.add_subaction("Failed to retrieve blobs path".to_string()))?;
+        blobs_path(blobs_name).map_err(|e| e.add_subaction("Failed to retrieve blobs path".to_string()))?;
     let cmdline_file_path = format!("{}/cmdline", blobs_path);
     let mut cmdline_file = File::open(cmdline_file_path.clone()).map_err(|e| {
         new_nitro_cli_failure!(
@@ -311,12 +313,12 @@ pub fn describe_eif(eif_path: String) -> NitroCliResult<EifDescribeInfo> {
 /// - *init*: The initial init process that is bootstraping the environment.
 /// - *linuxkit*: A slightly modified version of linuxkit.
 /// - *cmdline*: A file containing the kernel commandline.
-fn blobs_path() -> NitroCliResult<String> {
+fn blobs_path(blobs_name: Option<String>) -> NitroCliResult<String> {
     // TODO Improve error message with a suggestion to the user
     // consider using the default path used by rpm install
     let blobs_res = std::env::var("NITRO_CLI_BLOBS");
-    if Path::new(BLOBS_DOWNLOAD_PATH).exists() {
-        return Ok(blobs_res.unwrap_or_else(|_| BLOBS_DOWNLOAD_PATH.to_string()));
+    if let Some(blobs_name) = blobs_name {
+        return Ok(blobs_res.unwrap_or_else(|_| format!("{BLOBS_DOWNLOAD_PATH}/{blobs_name}/").to_string()));
     }
     Ok(blobs_res.unwrap_or_else(|_| DEFAULT_BLOBS_PATH.to_string()))
 }
@@ -927,6 +929,11 @@ macro_rules! create_app {
                         Arg::new("metadata")
                             .long("metadata")
                             .help("Path to JSON containing the custom metadata provided by the user."),
+                    )
+                    .arg(
+                        Arg::new("blobs-name")
+                            .long("blobs-name")
+                            .help("The name of the requested binary set.")
                     ),
             )
             .subcommand(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ use common::commands_parser::{BuildEnclavesArgs, EmptyArgs, FetchBlobsArgs, RunE
 use common::json_output::{
     EifDescribeInfo, EnclaveBuildInfo, EnclaveTerminateInfo, MetadataDescribeInfo, EnclaveBlobsMetadata
 };
-use common::{enclave_proc_command_send_single, get_sockets_dir_path, ExitGracefully};
+use common::{enclave_proc_command_send_single, get_sockets_dir_path};
 use common::{EnclaveProcessCommandType, NitroCliErrorEnum, NitroCliFailure, NitroCliResult};
 use enclave_proc_comm::{
     enclave_proc_command_send_all, enclave_proc_handle_outputs, enclave_process_handle_all_replies,
@@ -588,22 +588,34 @@ pub fn get_file_pcr(path: String, pcr_type: PcrType) -> NitroCliResult<BTreeMap<
     Ok(result)
 }
 ///Binary fetching mechanism for `fetch-blobs` subcommand.
-pub async fn fetch_binaries(arg: FetchBlobsArgs){
+pub async fn fetch_binaries(arg: FetchBlobsArgs) -> NitroCliResult<()>{
     match arg {
         FetchBlobsArgs::Uri{uri, name} => {
-            fetch_from_uri(uri,name).await.map_err(|e|{
+            fetch_from_uri(uri,name.clone()).await
+            .map_err(|e|{
+                let _ = clear_dir_on_fail(name);
                 new_nitro_cli_failure!(&format!("Could not fetch from uri: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-            }).ok_or_exit_with_errno(None);
+            })?;
         }
         FetchBlobsArgs::Version{version,name}=> {
             let base_prefix = format!("s3://{DEFAULT_S3_BUCKET}/{version}/enclaves-blobs.txz");
-            fetch_from_uri(base_prefix,name).await
+            fetch_from_uri(base_prefix,name.clone()).await
             .map_err(|e|{
+                let _ = clear_dir_on_fail(name);
                 new_nitro_cli_failure!(&format!("Version mismatch: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-            }).ok_or_exit_with_errno(None);
+            })?;
         }
     }
+    Ok(())
 }
+fn clear_dir_on_fail(name: String) -> NitroCliResult<()>{
+    println!("fail reached");
+    let output_dir = format!("{BLOBS_DOWNLOAD_PATH}/{name}/");
+    fs::remove_dir_all(&output_dir).map_err(|e| {
+        new_nitro_cli_failure!(&format!("Could not remove download directory: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+    })?;
+    Ok(())
+} 
 fn unpack_blob_archive(data: bytes::Bytes, download_dir : &String) -> NitroCliResult<()>{
 
     let xz = XzDecoder::new(&data[..]);
@@ -612,7 +624,7 @@ fn unpack_blob_archive(data: bytes::Bytes, download_dir : &String) -> NitroCliRe
     archive.entries()
     .map_err(|e| {
         new_nitro_cli_failure!(&format!("Failed to read archive entries: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-    }).ok_or_exit_with_errno(None)
+    })?
     .filter_map(|e| e.ok())
     .filter(|e| {
         e.path().map(|p| {
@@ -630,16 +642,16 @@ fn unpack_blob_archive(data: bytes::Bytes, download_dir : &String) -> NitroCliRe
     fs::set_permissions(format!("{download_dir}/linuxkit",), fs::Permissions::from_mode(0o755))
         .map_err(|e| {
             new_nitro_cli_failure!(&format!("Could not set executable permissions: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-        }).ok_or_exit_with_errno(None);
+        })?;
     
 
     Ok(())
 }
 ///Lists default s3 bucket that contains pre-built binaries.
-pub async fn list_binaries() -> NitroCliResult<()>{//TODO! make output prettier
+pub async fn list_binaries() -> NitroCliResult<()>{
     let url = Url::parse(&format!("s3://{DEFAULT_S3_BUCKET}/")).map_err(|e| {
         new_nitro_cli_failure!(&format!("Could not read the provided URI: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-    }).ok_or_exit_with_errno(None);
+    })?;
     
     let bucket = url.host_str().ok_or("No bucket specified").unwrap();
     let config = aws_config::from_env().load().await;
@@ -690,13 +702,12 @@ pub async fn list_binaries() -> NitroCliResult<()>{//TODO! make output prettier
 }
 fn create_dir_for_binaries(name: String) -> NitroCliResult<String>{
     let output_dir = format!("{BLOBS_DOWNLOAD_PATH}/{name}/");
-    //TO:DO CHECK IF DIRECTORY EXIST
     if Path::new(&output_dir).exists(){
         return Err(new_nitro_cli_failure!(&format!("Provided name of the binary set is already exist."), NitroCliErrorEnum::BlobFetcherError));
     }
     fs::create_dir_all(&output_dir).map_err(|e| {
         new_nitro_cli_failure!(&format!("Could not create download directory: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-    }).ok_or_exit_with_errno(None);
+    })?;
 
     Ok(output_dir)
 }
@@ -704,37 +715,37 @@ fn create_dir_for_binaries(name: String) -> NitroCliResult<String>{
 async fn fetch_from_uri(uri: String, name : String) -> NitroCliResult<()> {
     let url = Url::parse(&uri).map_err(|e| {
         new_nitro_cli_failure!(&format!("Could not read the provided URI: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-    }).ok_or_exit_with_errno(None);
+    })?;
 
     let output_dir = create_dir_for_binaries(name).map_err(|e| {
-        new_nitro_cli_failure!(&format!("Could not read the provided URI: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-    }).ok_or_exit_with_errno(None);
+        new_nitro_cli_failure!(&format!("Could not create the output directory: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+    })?;
 
     match url.scheme() {
         "s3" => {
-            let data = fetch_from_s3(url).await;
+            let data = fetch_from_s3(url).await?;
 
             unpack_blob_archive(data,&output_dir)
                 .map_err(|e| {
                     new_nitro_cli_failure!(&format!("Could not unpack blob archive: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-                }).ok_or_exit_with_errno(None);
+                })?;
 
             create_blobs_metadata(uri, output_dir).map_err(|e| {
                 new_nitro_cli_failure!(&format!("Could not create metadata for fetched blobs: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-            }).ok_or_exit_with_errno(None);
+            })?;
 
             Ok(())
         }
         "http" | "https" => {
             
-            let bytes = fetch_from_http(&uri).await;
+            let bytes = fetch_from_http(&uri).await?;
             unpack_blob_archive(bytes,&output_dir)
                 .map_err(|e| {
                     new_nitro_cli_failure!(&format!("Could not unpack blob archive: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-                }).ok_or_exit_with_errno(None);
+                })?;
             create_blobs_metadata(uri, output_dir).map_err(|e| {
                 new_nitro_cli_failure!(&format!("Could not create metadata for fetched blobs: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-            }).ok_or_exit_with_errno(None);
+            })?;
             Ok(())
         },
         _ => {
@@ -742,7 +753,7 @@ async fn fetch_from_uri(uri: String, name : String) -> NitroCliResult<()> {
         }
     }
 }
-async fn fetch_from_s3(url: Url) -> bytes::Bytes{
+async fn fetch_from_s3(url: Url) -> NitroCliResult<bytes::Bytes>{
     let bucket = url.host_str().ok_or("No bucket specified").unwrap();
     let prefix = url.path().trim_start_matches('/');  // "releases/1.3/"
     let config = aws_config::from_env().load().await;
@@ -756,30 +767,30 @@ async fn fetch_from_s3(url: Url) -> bytes::Bytes{
         .await
         .map_err(|e| {
             new_nitro_cli_failure!(&format!("Could not fetch from s3 URI {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-        }).ok_or_exit_with_errno(None);
+        })?;
 
     let bytes = resp.body.collect().await
         .map_err(|e| {
             new_nitro_cli_failure!(&format!("Could not read s3 storage: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-        }).ok_or_exit_with_errno(None);
+        })?;
 
-    bytes.into_bytes()
+    Ok(bytes.into_bytes())
 }
 
-async fn fetch_from_http(uri: &String) -> bytes::Bytes{
+async fn fetch_from_http(uri: &String) -> NitroCliResult<bytes::Bytes>{
     let url = uri.trim_end_matches('/');
     let response = reqwest::get(url)
         .await
         .map_err(|e| {
             new_nitro_cli_failure!(&format!("Failed to download from HTTP: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-        }).ok_or_exit_with_errno(None);
+        })?;
     let bytes = response.bytes()
         .await
         .map_err(|e| {
             new_nitro_cli_failure!(&format!("Failed to read response body: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-        }).ok_or_exit_with_errno(None);
+        })?;
 
-    bytes
+    Ok(bytes)
 }
 fn create_blobs_metadata(uri: String,output_dir: String) -> NitroCliResult<()>{
     let metadata = EnclaveBlobsMetadata {
@@ -788,10 +799,10 @@ fn create_blobs_metadata(uri: String,output_dir: String) -> NitroCliResult<()>{
     };
     let json = serde_json::to_string_pretty(&metadata).map_err(|e| {
         new_nitro_cli_failure!(&format!("Could not serialize metadata: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-        }).ok_or_exit_with_errno(None);
+        })?;
     fs::write(format!("{output_dir}/.metadata.json"), json).map_err(|e| {
         new_nitro_cli_failure!(&format!("Could not create metadata: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-        }).ok_or_exit_with_errno(None);
+        })?;
     Ok(())
 }
 /// Macro defining the arguments configuration for a *Nitro CLI* application.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ use std::os::unix::net::UnixStream;
 use std::path::{PathBuf,Path};
 use url::Url;
 use aws_sdk_s3::Client;
+use xz2::read::XzDecoder; 
 use std::env::consts::ARCH;
 use common::commands_parser::{BuildEnclavesArgs, EmptyArgs, FetchBlobsArgs, RunEnclavesArgs};
 use common::json_output::{
@@ -587,11 +588,19 @@ pub async fn fetch_binaries(arg: FetchBlobsArgs){
             }).ok_or_exit_with_errno(None);
         }
         FetchBlobsArgs::Version(version) => {
-            fetch_from_uri(format!("s3://nitro-binaries-test/releases/{version}/")).await
+            let base_prefix = format!("s3://nitro-binaries-test/releases/{version}/");
+            fetch_from_uri(base_prefix).await
             .map_err(|e|{
                 new_nitro_cli_failure!(&format!("Version mismatch: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
             }).ok_or_exit_with_errno(None);
         }
+    }
+}
+fn find_arch() -> &'static str {
+    match ARCH {
+        "x86_64" => "build-X64/x86_64",
+        "aarch64" => "build-ARM64/aarch64",
+        _ => ".",
     }
 }
 /// Fetching from specific URI that user provided.
@@ -607,57 +616,47 @@ async fn fetch_from_uri(uri: String) -> NitroCliResult<PathBuf> {
     match url.scheme() {
         "s3" => {
             let bucket = url.host_str().ok_or("No bucket specified").unwrap();
-            let base_prefix = url.path().trim_start_matches('/');  // "releases/1.3/"
-
-            let arch_prefix = match ARCH {
-                "x86_64" => format!("{base_prefix}build-X64/x86_64/"),
-                "aarch64" => format!("{base_prefix}build-ARM64/aarch64/"),
-                _ => return Err(new_nitro_cli_failure!("Unsupported architecture", NitroCliErrorEnum::BlobFetcherError))
-            };
-
+            let prefix = url.path().trim_start_matches('/');  // "releases/1.3/"
             let config = aws_config::from_env().load().await;
             let client = Client::new(&config);
 
-            let objects = client
-                .list_objects_v2()
+            let resp = client
+                .get_object()
                 .bucket(bucket)
-                .prefix(&arch_prefix)
+                .key(prefix)
                 .send()
                 .await
                 .map_err(|e| {
-                    new_nitro_cli_failure!(&format!("Could not list objects from s3: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+                    new_nitro_cli_failure!(&format!("Could not fetch from s3 URI {:?}", e), NitroCliErrorEnum::BlobFetcherError)
                 }).ok_or_exit_with_errno(None);
 
-            for object in objects.contents().unwrap_or_default() {
-                let key = object.key().unwrap();
+            let bytes = resp.body.collect().await
+                .map_err(|e| {
+                    new_nitro_cli_failure!(&format!("Could not read s3 storage: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+                }).ok_or_exit_with_errno(None);
+            let data = bytes.into_bytes();
+            let xz = XzDecoder::new(&data[..]);
+            let mut archive = tar::Archive::new(xz);
+            
+            let arch_path = find_arch();
 
-                let file_name = Path::new(key)
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .unwrap_or(key);
-                
-                let resp = client
-                    .get_object()
-                    .bucket(bucket)
-                    .key(key)
-                    .send()
-                    .await
-                    .map_err(|e| {
-                        new_nitro_cli_failure!(&format!("Could not fetch from s3 URI {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-                    }).ok_or_exit_with_errno(None);
-
-                let bytes = resp.body.collect().await
-                    .map_err(|e| {
-                        new_nitro_cli_failure!(&format!("Could not read s3 storage: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-                    }).ok_or_exit_with_errno(None);
-                let data = bytes.into_bytes();
-
-                let output_path = PathBuf::from(BLOBS_DOWNLOAD_PATH);
-                fs::write(&output_path.join(file_name), data)
-                    .map_err(|e| {
-                        new_nitro_cli_failure!(&format!("Could not write content to download directory: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
-                    }).ok_or_exit_with_errno(None);
-            }
+            archive.entries()
+            .map_err(|e| {
+                new_nitro_cli_failure!(&format!("Failed to read archive entries: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+            }).ok_or_exit_with_errno(None)
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.path().map(|p| {
+                    let path_str = p.to_string_lossy();
+                    path_str.starts_with(&format!("enclaves-blobs/{arch_path}")) && !path_str.ends_with("/")
+                }).unwrap_or(false)
+            })
+            .for_each(|mut entry| {
+                let path = entry.path().unwrap();
+                let file_name = path.file_name().unwrap();
+                let target_path = Path::new(BLOBS_DOWNLOAD_PATH).join(file_name);
+                let _ = entry.unpack(&target_path);
+            });
             Ok(PathBuf::from(BLOBS_DOWNLOAD_PATH))
         }
         _ => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -599,6 +599,13 @@ pub async fn fetch_binaries(arg: FetchBlobsArgs){
                 new_nitro_cli_failure!(&format!("Version mismatch: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
             }).ok_or_exit_with_errno(None);
         }
+        FetchBlobsArgs::Latest{download_dir} => {
+            let base_prefix = format!("s3://{DEFAULT_S3_BUCKET}/latest/enclaves-blobs.txz");
+            fetch_from_uri(base_prefix,download_dir).await
+            .map_err(|e|{
+                new_nitro_cli_failure!(&format!("Version mismatch: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+            }).ok_or_exit_with_errno(None);
+        }
     }
 }
 fn unpack_blob_archive(data: bytes::Bytes, download_dir : String) -> NitroCliResult<()>{
@@ -929,14 +936,12 @@ macro_rules! create_app {
                         Arg::new("version")
                             .long("version")
                             .help("Version tag of requested binary version.")
-                            .required_unless_present_any(["URI","list"])
                             .conflicts_with_all(["URI","list"])
                     )
                     .arg(
                         Arg::new("URI")
                             .long("URI")
                             .help("URI of your binary storage.")
-                            .required_unless_present_any(["list","version"])
                             .conflicts_with_all(["list","version"])
                     )
                     .arg(
@@ -944,7 +949,6 @@ macro_rules! create_app {
                             .long("list")
                             .action(clap::ArgAction::SetTrue)
                             .help("The flag for listing default s3 bucket which contains pre-built binaries.")
-                            .required_unless_present_any(["URI","version","download-dir"])
                             .conflicts_with_all(["URI","version","download-dir"])
                         )
                     .arg(
@@ -952,9 +956,6 @@ macro_rules! create_app {
                             .long("download-dir")
                             .help("User specified download directory. In case user want to use multiple versions of binaries.")
                             .conflicts_with("list")
-                            .required_unless_present("list")
-                            .requires("URI")
-                            .requires("version")
                     )
             )
             .subcommand(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -733,6 +733,20 @@ macro_rules! create_app {
                     ),
             )
             .subcommand(
+                Command::new("fetch-blobs")
+                    .about("Pulls binaries from remote repository to build enclave image.")
+                    .arg(
+                        Arg::new("version")
+                            .long("version")
+                            .help("Version tag of requested binary version.")
+                    )
+                    .arg(
+                        Arg::new("URI")
+                            .long("URI")
+                            .help("URI of your binary storage."),
+                    ),
+            )
+            .subcommand(
                 Command::new("describe-eif")
                     .about("Returns information about the EIF found at a given path.")
                     .arg(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,16 +22,18 @@ use log::{debug, info};
 use sha2::{Digest, Sha384};
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
-use std::fs::{File, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
 use std::os::unix::net::UnixStream;
-use std::path::PathBuf;
+use std::path::{PathBuf,Path};
+use url::Url;
+use aws_sdk_s3::Client;
 
-use common::commands_parser::{BuildEnclavesArgs, EmptyArgs, RunEnclavesArgs};
+use common::commands_parser::{BuildEnclavesArgs, EmptyArgs, FetchBlobsArgs, RunEnclavesArgs};
 use common::json_output::{
     EifDescribeInfo, EnclaveBuildInfo, EnclaveTerminateInfo, MetadataDescribeInfo,
 };
-use common::{enclave_proc_command_send_single, get_sockets_dir_path};
+use common::{enclave_proc_command_send_single, get_sockets_dir_path, ExitGracefully};
 use common::{EnclaveProcessCommandType, NitroCliErrorEnum, NitroCliFailure, NitroCliResult};
 use enclave_proc_comm::{
     enclave_proc_command_send_all, enclave_proc_handle_outputs, enclave_process_handle_all_replies,
@@ -47,6 +49,8 @@ pub const CID_TO_CONSOLE_PORT_OFFSET: u32 = 10000;
 
 /// Default blobs path to be used if the corresponding environment variable is not set.
 const DEFAULT_BLOBS_PATH: &str = "/usr/share/nitro_enclaves/blobs/";
+/// Download path to be used to fetch binaries with `fetch-blobs` subcommand.
+const BLOBS_DOWNLOAD_PATH: &str = "/var/lib/nitro-cli/binaries/";
 
 /// Build an enclave image file with the provided arguments.
 pub fn build_enclaves(args: BuildEnclavesArgs) -> NitroCliResult<()> {
@@ -572,6 +576,87 @@ pub fn get_file_pcr(path: String, pcr_type: PcrType) -> NitroCliResult<BTreeMap<
     );
     Ok(result)
 }
+///Binary fetching mechanism for `fetch-blobs` subcommand.
+pub async fn fetch_binaries(arg: FetchBlobsArgs){
+    match arg {
+        FetchBlobsArgs::Uri(uri) => {
+            fetch_from_uri(uri).await.map_err(|e|{
+                new_nitro_cli_failure!(&format!("Could not fetch from uri: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+            }).ok_or_exit_with_errno(None);
+        }
+        FetchBlobsArgs::Version(version) => {
+            fetch_from_uri(format!("s3://nitro-binaries-test/releases/{version}/")).await
+            .map_err(|e|{
+                new_nitro_cli_failure!(&format!("Version mismatch: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+            }).ok_or_exit_with_errno(None);
+        }
+    }
+}
+/// Fetching from specific URI that user provided.
+async fn fetch_from_uri(uri: String) -> NitroCliResult<PathBuf> {
+    let url = Url::parse(&uri).map_err(|e| {
+        new_nitro_cli_failure!(&format!("Could not read the provided URI: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+    }).ok_or_exit_with_errno(None);
+
+    fs::create_dir_all(BLOBS_DOWNLOAD_PATH).map_err(|e| {
+        new_nitro_cli_failure!(&format!("Could not create download directory: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+    }).ok_or_exit_with_errno(None);
+
+    match url.scheme() {
+        "s3" => {
+            let bucket = url.host_str().ok_or("No bucket specified").unwrap();
+            let prefix = url.path().trim_start_matches('/');
+
+            let config = aws_config::from_env().load().await;
+            let client = Client::new(&config);
+
+            let objects = client
+                .list_objects_v2()
+                .bucket(bucket)
+                .prefix(prefix)
+                .send()
+                .await
+                .map_err(|e| {
+                    new_nitro_cli_failure!(&format!("Could not list objects from s3: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+                }).ok_or_exit_with_errno(None);
+
+            for object in objects.contents().unwrap_or_default() {
+                let key = object.key().unwrap();
+                let file_name = Path::new(key)
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or(key);
+                
+                let resp = client
+                    .get_object()
+                    .bucket(bucket)
+                    .key(key)
+                    .send()
+                    .await
+                    .map_err(|e| {
+                        new_nitro_cli_failure!(&format!("Could not fetch from s3 URI {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+                    }).ok_or_exit_with_errno(None);
+
+                let bytes = resp.body.collect().await
+                    .map_err(|e| {
+                        new_nitro_cli_failure!(&format!("Could not read s3 storage: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+                    }).ok_or_exit_with_errno(None);
+                let data = bytes.into_bytes();
+
+                let output_path = PathBuf::from(BLOBS_DOWNLOAD_PATH);
+                fs::write(&output_path.join(file_name), data)
+                    .map_err(|e| {
+                        new_nitro_cli_failure!(&format!("Could not write content to download directory: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
+                    }).ok_or_exit_with_errno(None);
+            }
+
+            Ok(PathBuf::from(BLOBS_DOWNLOAD_PATH))
+        }
+        _ => return Err(new_nitro_cli_failure!("Unsupported URI: ",
+            NitroCliErrorEnum::BlobFetcherError)),
+    }
+}
+
 
 /// Macro defining the arguments configuration for a *Nitro CLI* application.
 #[macro_export]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -609,7 +609,6 @@ pub async fn fetch_binaries(arg: FetchBlobsArgs) -> NitroCliResult<()>{
     Ok(())
 }
 fn clear_dir_on_fail(name: String) -> NitroCliResult<()>{
-    println!("fail reached");
     let output_dir = format!("{BLOBS_DOWNLOAD_PATH}/{name}/");
     fs::remove_dir_all(&output_dir).map_err(|e| {
         new_nitro_cli_failure!(&format!("Could not remove download directory: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
@@ -658,7 +657,7 @@ pub async fn list_binaries() -> NitroCliResult<()>{
     let client = Client::new(&config);
     
     let mut table = Table::new();
-    table.add_row(row![bFg->"Version", bFg->"Size", bFg->"Last Modified", bFg->"URI"]);
+    table.add_row(row![bFg->"Version", bFg->"Size", bFg->"Last Modified", bFg->"URI", bFg->"Location"]);
     
     let mut response = client
         .list_objects_v2()
@@ -685,11 +684,13 @@ pub async fn list_binaries() -> NitroCliResult<()>{
     
                         let uri = format!("s3://{}/{}", bucket, object.key().unwrap_or_default());
                         
+                        let location = is_binary_exist(uri.clone())?;
                         table.add_row(row![
                             version,
                             size,
                             last_modified,
-                            uri
+                            uri,
+                            location
                         ]);
                     }
                 }
@@ -699,6 +700,25 @@ pub async fn list_binaries() -> NitroCliResult<()>{
     }
     table.printstd();
     Ok(())
+}
+fn is_binary_exist(uri: String) -> NitroCliResult<String>{
+    if let Ok(entries) = fs::read_dir(BLOBS_DOWNLOAD_PATH){
+        for entry in entries{
+            if let Ok(entry) = entry{
+                let file_name = entry.file_name();
+                let f = std::fs::File::open(format!("{}/{}/.metadata.json",BLOBS_DOWNLOAD_PATH,file_name.to_string_lossy())).unwrap();
+                let metadata: EnclaveBlobsMetadata = serde_json::from_reader(f).unwrap();
+
+                if metadata.source == uri {
+                    return Ok(format!("{}/{}",BLOBS_DOWNLOAD_PATH,file_name.to_string_lossy()));
+                }
+            }
+        }
+    }
+    else{
+        return Err(new_nitro_cli_failure!(&format!("Blobs download path not found or corrupted."), NitroCliErrorEnum::BlobFetcherError));
+    }
+    return Ok("".to_string())
 }
 fn create_dir_for_binaries(name: String) -> NitroCliResult<String>{
     let output_dir = format!("{BLOBS_DOWNLOAD_PATH}/{name}/");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,6 @@ pub const CID_TO_CONSOLE_PORT_OFFSET: u32 = 10000;
 
 /// Default blobs path to be used if the corresponding environment variable is not set.
 const DEFAULT_BLOBS_PATH: &str = "/usr/share/nitro_enclaves/blobs/";
-/// Download path to be used to fetch binaries with `fetch-blobs` subcommand.
-const BLOBS_DOWNLOAD_PATH: &str = "/var/lib/nitro-cli/binaries";
 ///Default S3 bucket which stores pre-built binaries.
 const DEFAULT_S3_BUCKET: &str = "nitro-binaries-test";
 /// Build an enclave image file with the provided arguments.
@@ -319,7 +317,7 @@ fn blobs_path(blobs_name: Option<String>) -> NitroCliResult<String> {
     // consider using the default path used by rpm install
     let blobs_res = std::env::var("NITRO_CLI_BLOBS");
     if let Some(blobs_name) = blobs_name {
-        return Ok(blobs_res.unwrap_or_else(|_| format!("{BLOBS_DOWNLOAD_PATH}/{blobs_name}/").to_string()));
+        return Ok(blobs_res.unwrap_or_else(|_| format!("{}/{blobs_name}/",get_blobs_download_path()).to_string()));
     }
     Ok(blobs_res.unwrap_or_else(|_| DEFAULT_BLOBS_PATH.to_string()))
 }
@@ -593,7 +591,9 @@ pub async fn fetch_binaries(arg: FetchBlobsArgs) -> NitroCliResult<()>{
         FetchBlobsArgs::Uri{uri, name} => {
             fetch_from_uri(uri,name.clone()).await
             .map_err(|e|{
-                let _ = clear_dir_on_fail(name);
+                if !format!("{:?}", e).contains("Provided name of the binary set is already exist") {
+                    let _ = clear_dir_on_fail(name);
+                }
                 new_nitro_cli_failure!(&format!("Could not fetch from uri: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
             })?;
         }
@@ -601,7 +601,9 @@ pub async fn fetch_binaries(arg: FetchBlobsArgs) -> NitroCliResult<()>{
             let base_prefix = format!("s3://{DEFAULT_S3_BUCKET}/{version}/enclaves-blobs.txz");
             fetch_from_uri(base_prefix,name.clone()).await
             .map_err(|e|{
-                let _ = clear_dir_on_fail(name);
+                if !format!("{:?}", e).contains("Provided name of the binary set is already exist") {
+                    let _ = clear_dir_on_fail(name);
+                }
                 new_nitro_cli_failure!(&format!("Version mismatch: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
             })?;
         }
@@ -609,7 +611,7 @@ pub async fn fetch_binaries(arg: FetchBlobsArgs) -> NitroCliResult<()>{
     Ok(())
 }
 fn clear_dir_on_fail(name: String) -> NitroCliResult<()>{
-    let output_dir = format!("{BLOBS_DOWNLOAD_PATH}/{name}/");
+    let output_dir = format!("{}/{name}/",get_blobs_download_path());
     fs::remove_dir_all(&output_dir).map_err(|e| {
         new_nitro_cli_failure!(&format!("Could not remove download directory: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
     })?;
@@ -703,15 +705,15 @@ pub async fn list_binaries() -> NitroCliResult<()>{
     Ok(())
 }
 fn is_binary_exist(uri: String) -> NitroCliResult<String>{
-    if let Ok(entries) = fs::read_dir(BLOBS_DOWNLOAD_PATH){
+    if let Ok(entries) = fs::read_dir(get_blobs_download_path()){
         for entry in entries{
             if let Ok(entry) = entry{
                 let file_name = entry.file_name();
-                let f = std::fs::File::open(format!("{}/{}/.metadata.json",BLOBS_DOWNLOAD_PATH,file_name.to_string_lossy())).unwrap();
+                let f = std::fs::File::open(format!("{}/{}/.metadata.json",get_blobs_download_path(),file_name.to_string_lossy())).unwrap();
                 let metadata: EnclaveBlobsMetadata = serde_json::from_reader(f).unwrap();
 
                 if metadata.source == uri {
-                    return Ok(format!("{}/{}",BLOBS_DOWNLOAD_PATH,file_name.to_string_lossy()));
+                    return Ok(format!("{}/{}",get_blobs_download_path(),file_name.to_string_lossy()));
                 }
             }
         }
@@ -722,7 +724,7 @@ fn is_binary_exist(uri: String) -> NitroCliResult<String>{
     return Ok("".to_string())
 }
 fn create_dir_for_binaries(name: String) -> NitroCliResult<String>{
-    let output_dir = format!("{BLOBS_DOWNLOAD_PATH}/{name}/");
+    let output_dir = format!("{}/{name}/",get_blobs_download_path());
     if Path::new(&output_dir).exists(){
         return Err(new_nitro_cli_failure!(&format!("Provided name of the binary set is already exist."), NitroCliErrorEnum::BlobFetcherError));
     }
@@ -835,6 +837,13 @@ pub fn create_blobs_metadata(uri: String,output_dir: String) -> NitroCliResult<(
         })?;
     Ok(())
 }
+fn get_blobs_download_path() -> String {
+    format!("{}/.nitro_cli/binaries",
+        dirs::home_dir()
+            .expect("Could not find home directory")
+            .to_string_lossy())
+}
+
 /// Macro defining the arguments configuration for a *Nitro CLI* application.
 #[macro_export]
 macro_rules! create_app {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ use std::os::unix::net::UnixStream;
 use std::path::{PathBuf,Path};
 use url::Url;
 use aws_sdk_s3::Client;
-
+use std::env::consts::ARCH;
 use common::commands_parser::{BuildEnclavesArgs, EmptyArgs, FetchBlobsArgs, RunEnclavesArgs};
 use common::json_output::{
     EifDescribeInfo, EnclaveBuildInfo, EnclaveTerminateInfo, MetadataDescribeInfo,
@@ -50,7 +50,7 @@ pub const CID_TO_CONSOLE_PORT_OFFSET: u32 = 10000;
 /// Default blobs path to be used if the corresponding environment variable is not set.
 const DEFAULT_BLOBS_PATH: &str = "/usr/share/nitro_enclaves/blobs/";
 /// Download path to be used to fetch binaries with `fetch-blobs` subcommand.
-const BLOBS_DOWNLOAD_PATH: &str = "/var/lib/nitro-cli/binaries/";
+const BLOBS_DOWNLOAD_PATH: &str = "/var/lib/nitro-cli/binaries";
 
 /// Build an enclave image file with the provided arguments.
 pub fn build_enclaves(args: BuildEnclavesArgs) -> NitroCliResult<()> {
@@ -309,7 +309,9 @@ fn blobs_path() -> NitroCliResult<String> {
     // TODO Improve error message with a suggestion to the user
     // consider using the default path used by rpm install
     let blobs_res = std::env::var("NITRO_CLI_BLOBS");
-
+    if Path::new(BLOBS_DOWNLOAD_PATH).exists() {
+        return Ok(blobs_res.unwrap_or_else(|_| BLOBS_DOWNLOAD_PATH.to_string()));
+    }
     Ok(blobs_res.unwrap_or_else(|_| DEFAULT_BLOBS_PATH.to_string()))
 }
 
@@ -605,7 +607,13 @@ async fn fetch_from_uri(uri: String) -> NitroCliResult<PathBuf> {
     match url.scheme() {
         "s3" => {
             let bucket = url.host_str().ok_or("No bucket specified").unwrap();
-            let prefix = url.path().trim_start_matches('/');
+            let base_prefix = url.path().trim_start_matches('/');  // "releases/1.3/"
+
+            let arch_prefix = match ARCH {
+                "x86_64" => format!("{base_prefix}build-X64/x86_64/"),
+                "aarch64" => format!("{base_prefix}build-ARM64/aarch64/"),
+                _ => return Err(new_nitro_cli_failure!("Unsupported architecture", NitroCliErrorEnum::BlobFetcherError))
+            };
 
             let config = aws_config::from_env().load().await;
             let client = Client::new(&config);
@@ -613,7 +621,7 @@ async fn fetch_from_uri(uri: String) -> NitroCliResult<PathBuf> {
             let objects = client
                 .list_objects_v2()
                 .bucket(bucket)
-                .prefix(prefix)
+                .prefix(&arch_prefix)
                 .send()
                 .await
                 .map_err(|e| {
@@ -622,6 +630,7 @@ async fn fetch_from_uri(uri: String) -> NitroCliResult<PathBuf> {
 
             for object in objects.contents().unwrap_or_default() {
                 let key = object.key().unwrap();
+
                 let file_name = Path::new(key)
                     .file_name()
                     .and_then(|name| name.to_str())
@@ -649,13 +658,14 @@ async fn fetch_from_uri(uri: String) -> NitroCliResult<PathBuf> {
                         new_nitro_cli_failure!(&format!("Could not write content to download directory: {:?}", e), NitroCliErrorEnum::BlobFetcherError)
                     }).ok_or_exit_with_errno(None);
             }
-
             Ok(PathBuf::from(BLOBS_DOWNLOAD_PATH))
         }
-        _ => return Err(new_nitro_cli_failure!("Unsupported URI: ",
-            NitroCliErrorEnum::BlobFetcherError)),
+        _ => {
+            Err(new_nitro_cli_failure!("Unsupported URI scheme", NitroCliErrorEnum::BlobFetcherError))
+        }
     }
 }
+
 
 
 /// Macro defining the arguments configuration for a *Nitro CLI* application.

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@
 extern crate lazy_static;
 
 use clap::{Arg, Command};
+use futures_util::TryFutureExt;
 use log::info;
 use std::os::unix::net::UnixStream;
 
@@ -27,7 +28,7 @@ use nitro_cli::enclave_proc_comm::{
     enclave_proc_get_flags, enclave_proc_spawn, enclave_process_handle_all_replies,
 };
 use nitro_cli::{
-    build_enclaves, console_enclaves, create_app, describe_eif, fetch_binaries, get_all_enclave_names, get_file_pcr, new_enclave_name, new_nitro_cli_failure, terminate_all_enclaves
+    build_enclaves, console_enclaves, create_app, describe_eif, fetch_binaries, get_all_enclave_names, get_file_pcr, list_binaries, new_enclave_name, new_nitro_cli_failure, terminate_all_enclaves
 };
 
 const RUN_ENCLAVE_STR: &str = "Run Enclave";
@@ -41,6 +42,7 @@ const EXPLAIN_ERR_STR: &str = "Explain Error";
 const NEW_NAME_STR: &str = "New Enclave Name";
 const FILE_PCR_STR: &str = "File PCR";
 const FETCH_BLOBS_STR: &str = "Fetch Blobs";
+const LIST_BLOBS_STR: &str = "List Blobs";
 /// *Nitro CLI* application entry point.
 fn main() {
     let version_str = env!("CARGO_PKG_VERSION");
@@ -226,14 +228,22 @@ fn main() {
                 .ok_or_exit_with_errno(None);
         }
         Some(("fetch-blobs", args)) => {
-            let fetch_args = FetchBlobsArgs::new_with(args)
-                .map_err(|e|{
-                    e.add_subaction("Failed to construct FetchBlobs arguments".to_string())
-                        .set_action(FETCH_BLOBS_STR.to_string())
-                })
-                .ok_or_exit_with_errno(None);
             let rt = tokio::runtime::Runtime::new().expect("Failed to create runtime");
-            rt.block_on(fetch_binaries(fetch_args));
+            if args.get_flag("list"){
+                rt.block_on(list_binaries().map_err(|e| {
+                    e.add_subaction("Failed to build enclave".to_string())
+                        .set_action(LIST_BLOBS_STR.to_string())
+                })).ok_or_exit_with_errno(None);
+            }
+            else{
+                let fetch_args = FetchBlobsArgs::new_with(args)
+                    .map_err(|e|{
+                        e.add_subaction("Failed to construct FetchBlobs arguments".to_string())
+                            .set_action(FETCH_BLOBS_STR.to_string())
+                    })
+                    .ok_or_exit_with_errno(None);
+                rt.block_on(fetch_binaries(fetch_args));
+            }
         }
         Some(("describe-eif", args)) => {
             let eif_path = args

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,6 +227,10 @@ fn main() {
                 })
                 .ok_or_exit_with_errno(None);
         }
+        Some(("fetch-blobs", args)) => {
+            println!("fetched from remote repository! {:?}", args);
+            unimplemented!();
+        }
         Some(("describe-eif", args)) => {
             let eif_path = args
                 .get_one::<String>("eif-path")

--- a/src/main.rs
+++ b/src/main.rs
@@ -231,7 +231,7 @@ fn main() {
             let rt = tokio::runtime::Runtime::new().expect("Failed to create runtime");
             if args.get_flag("list"){
                 rt.block_on(list_binaries().map_err(|e| {
-                    e.add_subaction("Failed to build enclave".to_string())
+                    e.add_subaction("Failed to list upstream binaries.".to_string())
                         .set_action(LIST_BLOBS_STR.to_string())
                 })).ok_or_exit_with_errno(None);
             }
@@ -242,7 +242,13 @@ fn main() {
                             .set_action(FETCH_BLOBS_STR.to_string())
                     })
                     .ok_or_exit_with_errno(None);
-                rt.block_on(fetch_binaries(fetch_args));
+                rt.block_on(
+                    fetch_binaries(fetch_args)
+                    .map_err(|e|{
+                        e.add_subaction("Failed to fetch binaries".to_string())
+                            .set_action(FETCH_BLOBS_STR.to_string())
+                    })
+                ).ok_or_exit_with_errno(None);
             }
         }
         Some(("describe-eif", args)) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,7 @@ use log::info;
 use std::os::unix::net::UnixStream;
 
 use nitro_cli::common::commands_parser::{
-    BuildEnclavesArgs, ConsoleArgs, DescribeEnclavesArgs, EmptyArgs, ExplainArgs, PcrArgs,
-    RunEnclavesArgs, TerminateEnclavesArgs,
+    BuildEnclavesArgs, ConsoleArgs, DescribeEnclavesArgs, EmptyArgs, ExplainArgs, FetchBlobsArgs, PcrArgs, RunEnclavesArgs, TerminateEnclavesArgs
 };
 use nitro_cli::common::document_errors::explain_error;
 use nitro_cli::common::json_output::{EnclaveDescribeInfo, EnclaveRunInfo, EnclaveTerminateInfo};
@@ -28,8 +27,7 @@ use nitro_cli::enclave_proc_comm::{
     enclave_proc_get_flags, enclave_proc_spawn, enclave_process_handle_all_replies,
 };
 use nitro_cli::{
-    build_enclaves, console_enclaves, create_app, describe_eif, get_all_enclave_names,
-    get_file_pcr, new_enclave_name, new_nitro_cli_failure, terminate_all_enclaves,
+    build_enclaves, console_enclaves, create_app, describe_eif, fetch_binaries, get_all_enclave_names, get_file_pcr, new_enclave_name, new_nitro_cli_failure, terminate_all_enclaves
 };
 
 const RUN_ENCLAVE_STR: &str = "Run Enclave";
@@ -42,7 +40,7 @@ const ENCLAVE_CONSOLE_STR: &str = "Enclave Console";
 const EXPLAIN_ERR_STR: &str = "Explain Error";
 const NEW_NAME_STR: &str = "New Enclave Name";
 const FILE_PCR_STR: &str = "File PCR";
-
+const FETCH_BLOBS_STR: &str = "Fetch Blobs";
 /// *Nitro CLI* application entry point.
 fn main() {
     let version_str = env!("CARGO_PKG_VERSION");
@@ -228,8 +226,14 @@ fn main() {
                 .ok_or_exit_with_errno(None);
         }
         Some(("fetch-blobs", args)) => {
-            println!("fetched from remote repository! {:?}", args);
-            unimplemented!();
+            let fetch_args = FetchBlobsArgs::new_with(args)
+                .map_err(|e|{
+                    e.add_subaction("Failed to construct FetchBlobs arguments".to_string())
+                        .set_action(FETCH_BLOBS_STR.to_string())
+                })
+                .ok_or_exit_with_errno(None);
+            let rt = tokio::runtime::Runtime::new().expect("Failed to create runtime");
+            rt.block_on(fetch_binaries(fetch_args));
         }
         Some(("describe-eif", args)) => {
             let eif_path = args

--- a/tests/test_nitro_cli_args.rs
+++ b/tests/test_nitro_cli_args.rs
@@ -690,4 +690,52 @@ mod test_nitro_cli_args {
 
         assert!(app.try_get_matches_from(args).is_ok())
     }
+    #[test]
+    fn fetch_blobs_version_requires_blobs_name() {
+        let app = create_app!();
+        let args = vec!["nitro-cli", "fetch-blobs", "--version", "1.0"];
+        assert!(app.try_get_matches_from(args).is_err());
+    }
+
+    #[test]
+    fn fetch_blobs_uri_requires_blobs_name() {
+        let app = create_app!();
+        let args = vec!["nitro-cli", "fetch-blobs", "--URI", "https://example.com"];
+        assert!(app.try_get_matches_from(args).is_err());
+    }
+
+    #[test]
+    fn fetch_blobs_list_conflicts_with_version() {
+        let app = create_app!();
+        let args = vec!["nitro-cli", "fetch-blobs", "--list", "--version", "1.0"];
+        assert!(app.try_get_matches_from(args).is_err());
+    }
+
+    #[test]
+    fn fetch_blobs_valid_version_and_blobs_name() {
+        let app = create_app!();
+        let args = vec!["nitro-cli", "fetch-blobs", "--version", "1.0", "--blobs-name", "test"];
+        assert!(app.try_get_matches_from(args).is_ok());
+    }
+
+    #[test]
+    fn fetch_blobs_valid_uri_and_blobs_name() {
+        let app = create_app!();
+        let args = vec!["nitro-cli", "fetch-blobs", "--URI", "https://example.com", "--blobs-name", "test"];
+        assert!(app.try_get_matches_from(args).is_ok());
+    }
+
+    #[test]
+    fn fetch_blobs_list_alone_is_valid() {
+        let app = create_app!();
+        let args = vec!["nitro-cli", "fetch-blobs", "--list"];
+        assert!(app.try_get_matches_from(args).is_ok());
+    }
+
+    #[test]
+    fn fetch_blobs_version_and_uri_conflict() {
+        let app = create_app!();
+        let args = vec!["nitro-cli", "fetch-blobs", "--version", "1.0", "--URI", "https://example.com", "--blobs-name", "test"];
+        assert!(app.try_get_matches_from(args).is_err());
+    }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -84,6 +84,7 @@ mod tests {
             img_name: None,
             img_version: None,
             metadata: None,
+            blobs_name: None,
         };
 
         assert!(build_enclaves(args).is_err());
@@ -103,6 +104,7 @@ mod tests {
             img_name: None,
             img_version: None,
             metadata: None,
+            blobs_name: None,
         };
 
         let measurements = build_from_docker(
@@ -114,6 +116,7 @@ mod tests {
             &args.img_name,
             &args.img_version,
             &args.metadata,
+            args.blobs_name,
         )
         .expect("Docker build failed")
         .1;
@@ -145,6 +148,7 @@ mod tests {
             img_name: None,
             img_version: None,
             metadata: None,
+            blobs_name: None,
         };
 
         build_from_docker(
@@ -156,6 +160,7 @@ mod tests {
             &args.img_name,
             &args.img_version,
             &args.metadata,
+            args.blobs_name,
         )
         .expect("Docker build failed");
     }
@@ -174,6 +179,7 @@ mod tests {
             img_name: None,
             img_version: None,
             metadata: None,
+            blobs_name: None,
         };
 
         build_from_docker(
@@ -185,6 +191,7 @@ mod tests {
             &args.img_name,
             &args.img_version,
             &args.metadata,
+            args.blobs_name,
         )
         .expect("Docker build failed");
     }
@@ -249,6 +256,7 @@ mod tests {
             img_name: None,
             img_version: None,
             metadata: None,
+            blobs_name: None,
         };
 
         let measurements = build_from_docker(
@@ -260,6 +268,7 @@ mod tests {
             &args.img_name,
             &args.img_version,
             &args.metadata,
+            args.blobs_name,
         )
         .expect("Docker build failed")
         .1;
@@ -292,6 +301,7 @@ mod tests {
             img_name: None,
             img_version: None,
             metadata: None,
+            blobs_name: None
         };
 
         build_from_docker(
@@ -303,6 +313,7 @@ mod tests {
             &build_args.img_name,
             &build_args.img_version,
             &build_args.metadata,
+            build_args.blobs_name,
         )
         .expect("Docker build failed");
 
@@ -338,6 +349,7 @@ mod tests {
             img_name: None,
             img_version: None,
             metadata: None,
+            blobs_name: None,
         };
 
         build_from_docker(
@@ -349,6 +361,7 @@ mod tests {
             &build_args.img_name,
             &build_args.img_version,
             &build_args.metadata,
+            build_args.blobs_name,
         )
         .expect("Docker build failed");
 
@@ -379,6 +392,7 @@ mod tests {
             img_name: None,
             img_version: None,
             metadata: None,
+            blobs_name: None,
         };
 
         build_from_docker(
@@ -390,6 +404,7 @@ mod tests {
             &build_args.img_name,
             &build_args.img_version,
             &build_args.metadata,
+            build_args.blobs_name
         )
         .expect("Docker build failed");
 
@@ -486,6 +501,7 @@ mod tests {
             img_name: None,
             img_version: None,
             metadata: None,
+            blobs_name: None,
         };
 
         build_from_docker(
@@ -497,6 +513,7 @@ mod tests {
             &build_args.img_name,
             &build_args.img_version,
             &build_args.metadata,
+            build_args.blobs_name,
         )
         .expect("Docker build failed");
 
@@ -528,6 +545,7 @@ mod tests {
             img_name: None,
             img_version: None,
             metadata: None,
+            blobs_name: None,
         };
 
         build_from_docker(
@@ -539,6 +557,7 @@ mod tests {
             &build_args.img_name,
             &build_args.img_version,
             &build_args.metadata,
+            build_args.blobs_name,
         )
         .expect("Docker build failed");
 
@@ -590,6 +609,7 @@ mod tests {
             img_name: None,
             img_version: None,
             metadata: None,
+            blobs_name: None,
         };
 
         build_from_docker(
@@ -601,6 +621,7 @@ mod tests {
             &build_args.img_name,
             &build_args.img_version,
             &build_args.metadata,
+            build_args.blobs_name,
         )
         .expect("Docker build failed");
 
@@ -680,6 +701,7 @@ mod tests {
             img_name: None,
             img_version: None,
             metadata: None,
+            blobs_name: None,
         };
 
         build_from_docker(
@@ -691,6 +713,7 @@ mod tests {
             &args.img_name,
             &args.img_version,
             &args.metadata,
+            args.blobs_name,
         )
         .expect("Docker build failed");
 
@@ -771,6 +794,7 @@ mod tests {
             img_name: Some("TestName".to_string()),
             img_version: Some("1.0".to_string()),
             metadata: Some(meta_path.to_str().unwrap().to_string()),
+            blobs_name: None,
         };
 
         build_from_docker(
@@ -782,6 +806,7 @@ mod tests {
             &args.img_name,
             &args.img_version,
             &args.metadata,
+            args.blobs_name,
         )
         .expect("Docker build failed");
 
@@ -865,6 +890,7 @@ mod tests {
             img_name: None,
             img_version: None,
             metadata: None,
+            blobs_name: None,
         };
 
         build_from_docker(
@@ -876,6 +902,7 @@ mod tests {
             &args.img_name,
             &args.img_version,
             &args.metadata,
+            args.blobs_name,
         )
         .expect("Docker build failed");
 
@@ -964,6 +991,7 @@ mod tests {
             img_name: None,
             img_version: None,
             metadata: None,
+            blobs_name: None,
         };
 
         build_from_docker(
@@ -975,6 +1003,7 @@ mod tests {
             &args.img_name,
             &args.img_version,
             &args.metadata,
+            args.blobs_name,
         )
         .expect("Docker build failed");
 
@@ -1006,6 +1035,7 @@ mod tests {
             img_name: None,
             img_version: None,
             metadata: None,
+            blobs_name: None,
         };
 
         build_from_docker(
@@ -1017,6 +1047,7 @@ mod tests {
             &args.img_name,
             &args.img_version,
             &args.metadata,
+            args.blobs_name,
         )
         .expect("Docker build failed");
 
@@ -1048,6 +1079,7 @@ mod tests {
             img_name: None,
             img_version: None,
             metadata: None,
+            blobs_name: None,
         };
 
         build_from_docker(
@@ -1059,6 +1091,7 @@ mod tests {
             &args.img_name,
             &args.img_version,
             &args.metadata,
+            args.blobs_name,
         )
         .expect("Docker build failed");
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -17,7 +17,7 @@ mod tests {
     use nitro_cli::utils::{Console, PcrType};
     use nitro_cli::{
         build_enclaves, build_from_docker, describe_eif, enclave_console, get_file_pcr,
-        new_enclave_name,
+        new_enclave_name, fetch_from_http, unpack_blob_archive, create_blobs_metadata
     };
     use nitro_cli::{CID_TO_CONSOLE_PORT_OFFSET, VMADDR_CID_HYPERVISOR};
     use serde_json::json;
@@ -25,6 +25,13 @@ mod tests {
     use std::fs::{File, OpenOptions};
     use std::io::Write;
     use tempfile::{tempdir, TempDir};
+    use xz2::write::XzEncoder;
+    use bytes::Bytes;
+    use tar::{Builder, Header};
+    use std::path::Path;
+    use wiremock::{MockServer, Mock, ResponseTemplate};
+    use wiremock::matchers::{method, path};
+    use std::env::consts::ARCH;
 
     use openssl::asn1::Asn1Time;
     use openssl::ec::{EcGroup, EcKey};
@@ -1108,5 +1115,122 @@ mod tests {
                 .unwrap(),
             pcr.get(&"PCR8".to_string()).unwrap(),
         );
+    }
+    #[test]
+    fn test_unpack_blob_archive_normal() {
+        let test_data = create_test_archive(ARCH);
+        let temp_dir = TempDir::new().unwrap();
+        let download_dir = temp_dir.path().to_string_lossy().to_string();
+
+        let result = unpack_blob_archive(test_data, &download_dir);
+        assert!(result.is_ok());
+
+        // Verify expected files based on architecture
+        let expected_files = match ARCH {
+            "x86_64" => vec!["bzImage", "bzImage.config", "cmdline", "init", "linuxkit", "nsm.ko"],
+            "aarch64" => vec!["Image", "Image.config", "cmdline", "init", "linuxkit", "nsm.ko"],
+            _ => panic!("Unsupported architecture for testing: {}", ARCH),
+        };
+
+        for file in &expected_files {
+            let file_path = std::path::Path::new(&download_dir).join(file);
+            assert!(file_path.exists(), "File {} should exist", file);
+        }
+    }
+    #[test]
+    fn test_create_blobs_metadata() {
+        // Create a temporary directory for testing
+        let temp_dir = TempDir::new().unwrap();
+        let output_dir = temp_dir.path().to_string_lossy().to_string();
+        let test_uri = "s3://test-bucket/test-blob.txz".to_string();
+
+        // Test successful metadata creation
+        let result = create_blobs_metadata(test_uri.clone(), output_dir.clone());
+        assert!(result.is_ok(), "Metadata creation should succeed");
+
+        // Verify the metadata file exists
+        let metadata_path = std::path::Path::new(&output_dir).join(".metadata.json");
+        assert!(metadata_path.exists(), "Metadata file should exist");
+
+        // Verify basic content
+        let metadata_content = std::fs::read_to_string(metadata_path).unwrap();
+        assert!(metadata_content.contains(&test_uri), "Metadata should contain the URI");
+
+        // Test with invalid directory
+        let result = create_blobs_metadata(test_uri, "/nonexistent/directory".to_string());
+        assert!(result.is_err(), "Should fail with invalid directory");
+    }
+    fn create_test_archive(arch: &str) -> Bytes {
+        let tar_data = Vec::new();
+        let mut builder = Builder::new(tar_data);
+
+        let files = match arch {
+            "x86_64" => vec![
+                ("bzImage", "Mock bzImage content", 0o644),
+                ("bzImage.config", "Mock bzImage.config content", 0o644),
+                ("cmdline", "console=ttyS0 reboot=k panic=1 pci=off", 0o644),
+                ("init", "Mock init content", 0o755),
+                ("linuxkit", "Mock linuxkit content", 0o755),
+                ("nsm.ko", "Mock nsm.ko content", 0o644),
+            ],
+            "aarch64" => vec![
+                ("Image", "Mock Image content", 0o644),
+                ("Image.config", "Mock Image.config content", 0o644),
+                ("cmdline", "console=ttyS0 reboot=k panic=1 pci=off", 0o644),
+                ("init", "Mock init content", 0o755),
+                ("linuxkit", "Mock linuxkit content", 0o755),
+                ("nsm.ko", "Mock nsm.ko content", 0o644),
+            ],
+            _ => panic!("Unsupported architecture for testing: {}", arch),
+        };
+
+        for (filename, content, mode) in files {
+            let mut header = Header::new_gnu();
+            let content_bytes = content.as_bytes();
+            header.set_size(content_bytes.len() as u64);
+            header.set_mode(mode);
+            header.set_cksum();
+
+            let path = format!("{}/{}", arch, filename);
+            builder.append_data(&mut header, &path, content_bytes).unwrap();
+        }
+
+        let tar_data = builder.into_inner().unwrap();
+        let mut xz = XzEncoder::new(Vec::new(), 6);
+        xz.write_all(&tar_data).unwrap();
+        Bytes::from(xz.finish().unwrap())
+    }
+
+    #[tokio::test]
+    async fn test_fetch_from_http() {
+        // Start a mock server
+        let mock_server = MockServer::start().await;
+
+        // Mock successful response
+        Mock::given(method("GET"))
+            .and(path("/blob.txz"))
+            .respond_with(ResponseTemplate::new(200)
+                .set_body_raw(vec![1, 2, 3, 4], "application/octet-stream"))
+            .mount(&mock_server)
+            .await;
+
+        // Mock 404 Not Found response
+        Mock::given(method("GET"))
+            .and(path("/not-found.txz"))
+            .respond_with(ResponseTemplate::new(404)
+                .set_body_string("Not Found"))
+            .mount(&mock_server)
+            .await;
+
+        // Test successful fetch
+        let success_uri = format!("{}/blob.txz", mock_server.uri());
+        let result = fetch_from_http(&success_uri).await;
+        assert!(result.is_ok(), "Expected successful fetch");
+        assert_eq!(result.unwrap(), bytes::Bytes::from(vec![1, 2, 3, 4]));
+
+        // Test 404 Not Found error
+        let not_found_uri = format!("{}/not-found.txz", mock_server.uri());
+        let result = fetch_from_http(&not_found_uri).await;
+        assert!(result.is_err(), "Expected error for 404 Not Found");
     }
 }


### PR DESCRIPTION
*Description of changes:*

I have added a new sub-command under nitro-cli for fetching and listing binaries. The listing functionality currently works only with our default S3 bucket. However, users can fetch binaries from their own S3 bucket or provide a URI containing an archive of binaries. The sub-command will fetch these binaries and store them locally. The URI format is restricted to S3 or HTTP/HTTPS protocols. The archive file must follow a specific structure, including binaries for both arm64 and x86_64 architectures. The provided URI should directly point to the binary archive file. For users wanting to store multiple binaries, the --download-dir argument is available, allowing the fetch-blobs tool to store binaries in their specified location. Usage remains consistent with the existing workflow - binaries can be accessed through environmental variables as before. For private S3 URIs, users need to configure their AWS credentials using AWS tooling.

Examples of how to use:
`nitro-cli fetch-blobs --URI <URI>`
`nitro-cli fetch-blobs --URI <URI> --download-dir <download directory>`
`nitro-cli fetch-blobs --version <version> #this is will fetch from our default s3 bucket`
`nitro-cli fetch-blobs --list`
`nitro-cli fetch-blobs #default way to fetch binaries. It will fetch the latest version we have in our s3 bucket.`

Please let me know if any commit messages need clarification or if you need more information about the implementation.