### PR TITLE
New Allocator Binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,18 +39,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator"
-version = "0.1.0"
-dependencies = [
- "lazy_static",
- "log",
- "serde",
- "serde_yaml 0.9.34+deprecated",
- "tempfile",
- "thiserror 2.0.11",
-]
-
-[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2046,6 +2034,18 @@ dependencies = [
  "tempfile",
  "vmm-sys-util",
  "vsock",
+]
+
+[[package]]
+name = "nitro-enclaves-allocator"
+version = "0.1.0"
+dependencies = [
+ "lazy_static",
+ "log",
+ "serde",
+ "serde_yaml 0.9.34+deprecated",
+ "tempfile",
+ "thiserror 2.0.11",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This repository contains a collection of tools and commands used for managing th
 ### How to install (GitHub sources):
   1. Clone the repository.
   2. Set NITRO_CLI_INSTALL_DIR to the desired location, by default everything will be installed in build/install
-  3. Run 'make nitro-cli && make vsock-proxy && make install'.
+  3. Run 'make nitro-cli && make vsock-proxy && make nitro-enclaves-allocator && make install'.
   4. [Rerun after reboot] Source the script ${NITRO_CLI_INSTALL_DIR}/etc/profile.d/nitro-cli-env.sh.
   5. [Rerun after reboot] Preallocate resources for the enclaves(s). 
      For example, to configure 2 vCPUs and 256 Mib for enclave use:

--- a/SPECS/aws-nitro-enclaves-cli.spec
+++ b/SPECS/aws-nitro-enclaves-cli.spec
@@ -79,6 +79,7 @@ cp tools/cargo_vendor_config_template .cargo/config
 %build
 make nitro-cli-native
 make vsock-proxy-native
+make nitro-enclaves-allocator-native
 
 
 %install

--- a/allocator/Cargo.toml
+++ b/allocator/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "allocator"
+name = "nitro-enclaves-allocator"
 version = "0.1.0"
 edition = "2021"
 

--- a/allocator/src/configuration.rs
+++ b/allocator/src/configuration.rs
@@ -20,7 +20,8 @@ pub enum ResourcePoolConfig {
 }
 
 pub fn get_resource_pool_from_config() -> Result<Vec<ResourcePool>, Box<dyn std::error::Error>> {
-    let f = std::fs::File::open("/etc/nitro_enclaves/allocator.yaml")?;
+    let f = std::fs::File::open(format!("{}/etc/nitro_enclaves/allocator.yaml",
+    std::env::var("NITRO_CLI_INSTALL_DIR").unwrap_err()))?;
     let config: ResourcePoolConfig = serde_yaml::from_reader(f)
         .map_err(|_| Error::ConfigFileCorruption)?;
     

--- a/allocator/src/configuration.rs
+++ b/allocator/src/configuration.rs
@@ -21,7 +21,7 @@ pub enum ResourcePoolConfig {
 
 pub fn get_resource_pool_from_config() -> Result<Vec<ResourcePool>, Box<dyn std::error::Error>> {
     let f = std::fs::File::open(format!("{}/etc/nitro_enclaves/allocator.yaml",
-    std::env::var("NITRO_CLI_INSTALL_DIR").unwrap_err()))?;
+    std::env::var("NITRO_CLI_INSTALL_DIR").unwrap_or("".to_string())))?;
     let config: ResourcePoolConfig = serde_yaml::from_reader(f)
         .map_err(|_| Error::ConfigFileCorruption)?;
     

--- a/bootstrap/allocator.yaml
+++ b/bootstrap/allocator.yaml
@@ -12,3 +12,15 @@ cpu_count: 2
 # Note: cpu_count and cpu_pool conflict with each other. Only use exactly one of them.
 # Example of reserving CPUs 2, 3, and 6 through 9:
 # cpu_pool: 2,3,6-9
+#
+# Allocator configuration for multiple enclaves
+# Each list item represents a separate enclave
+# Use YAML array like the example below.
+# Example:
+# - memory_mib: 512
+#   cpu_count: 2
+# - memory_mib: 512
+#   cpu_pool: 2,3,6-9
+# You can add more enclave configurations as needed.
+# Allocated Resources are not tied with enclaves.
+# It's a mechanism to separate resources from each other.

--- a/docs/centos_stream_8_how_to_install_nitro_cli_from_github_sources.md
+++ b/docs/centos_stream_8_how_to_install_nitro_cli_from_github_sources.md
@@ -157,6 +157,8 @@ $ make nitro-cli
 
 $ make vsock-proxy
 
+$ make nitro-enclaves-allocator
+
 $ sudo make NITRO_CLI_INSTALL_DIR=/ install
 
 $ source /etc/profile.d/nitro-cli-env.sh

--- a/docs/fedora_34_how_to_install_nitro_cli_from_github_sources.md
+++ b/docs/fedora_34_how_to_install_nitro_cli_from_github_sources.md
@@ -165,6 +165,8 @@ $ make nitro-cli
 
 $ make vsock-proxy
 
+$ make nitro-enclaves-allocator
+
 $ sudo make NITRO_CLI_INSTALL_DIR=/ install
 
 $ source /etc/profile.d/nitro-cli-env.sh

--- a/docs/rhel_8.4_how_to_install_nitro_cli_from_github_sources.md
+++ b/docs/rhel_8.4_how_to_install_nitro_cli_from_github_sources.md
@@ -161,6 +161,8 @@ $ make nitro-cli
 
 $ make vsock-proxy
 
+$ make nitro-enclaves-allocator
+
 $ sudo make NITRO_CLI_INSTALL_DIR=/ install
 
 $ source /etc/profile.d/nitro-cli-env.sh

--- a/docs/ubuntu_20.04_how_to_install_nitro_cli_from_github_sources.md
+++ b/docs/ubuntu_20.04_how_to_install_nitro_cli_from_github_sources.md
@@ -164,6 +164,8 @@ $ make nitro-cli
 
 $ make vsock-proxy
 
+$ make nitro-enclaves-allocator
+
 $ sudo make NITRO_CLI_INSTALL_DIR=/ install
 
 $ source /etc/profile.d/nitro-cli-env.sh

--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,7 @@ update_git() {
 }
 
 install_nitro_cli() {
-	make nitro-cli && make vsock-proxy && make install
+	make nitro-cli && make vsock-proxy && make nitro-enclaves-allocator && make install
 	source "${NITRO_CLI_INSTALL_DIR}"/etc/profile.d/nitro-cli-env.sh
 	echo "Nitro CLI is now installed. We recommend adding ${NITRO_CLI_INSTALL_DIR}/etc/profile.d/nitro-cli-env.sh in your .bashrc file"
 }

--- a/scripts/lib_tests.sh
+++ b/scripts/lib_tests.sh
@@ -108,6 +108,7 @@ build_and_install() {
 	make nitro_enclaves
 	make nitro-cli
 	make vsock-proxy
+	make nitro-enclaves-allocator
 	make install
 }
 


### PR DESCRIPTION
Changed makefile to build allocator as a separated binary. Since binary and the bash script has the same the allocator.service will pick up the new one.